### PR TITLE
Add user latency tracking

### DIFF
--- a/generator/scenarios/EVMTransfer.go
+++ b/generator/scenarios/EVMTransfer.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -49,7 +50,7 @@ func (s *EVMTransferScenario) CreateTransaction(config *config.LoadConfig, scena
 	tx := &ethtypes.DynamicFeeTx{
 		Nonce:     scenario.Nonce,
 		To:        &scenario.Receiver,
-		Value:     bigOne,
+		Value:     big.NewInt(time.Now().Unix()),
 		Gas:       21000,                   // Standard gas limit for ETH transfer
 		GasTipCap: big.NewInt(2000000000),  // 2 gwei
 		GasFeeCap: big.NewInt(20000000000), // 20 gwei

--- a/generator/utils/utils.go
+++ b/generator/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -47,6 +48,7 @@ func createTransactOpts(chainID *big.Int, account *loadtypes.Account, gasLimit u
 	// Set transaction parameters
 	auth.Nonce = big.NewInt(int64(account.Nonce))
 	auth.NoSend = noSend
+	auth.Value = big.NewInt(time.Now().Unix())
 
 	auth.GasLimit = gasLimit
 	auth.GasTipCap = big.NewInt(2000000000)  // 2 gwei tip (priority fee)

--- a/sender/dispatcher.go
+++ b/sender/dispatcher.go
@@ -133,7 +133,7 @@ func (d *Dispatcher) RunBatch(ctx context.Context, count int) error {
 	d.mu.RLock()
 	limiter := d.limiter
 	d.mu.RUnlock()
-	for i := 0; i < count; i++ {
+	for i := range count {
 		if err := limiter.Wait(ctx); err != nil {
 			return err
 		}

--- a/sender/dispatcher.go
+++ b/sender/dispatcher.go
@@ -133,14 +133,14 @@ func (d *Dispatcher) RunBatch(ctx context.Context, count int) error {
 	d.mu.RLock()
 	limiter := d.limiter
 	d.mu.RUnlock()
-	for i := range count {
+	for i := 0; i < count; i++ {
 		if err := limiter.Wait(ctx); err != nil {
 			return err
 		}
 		// Generate a transaction
 		tx, ok := d.generator.Generate()
 		if !ok {
-			return fmt.Errorf("Dispatcher: Generator returned nil transaction (batch %d/%d)\n", i+1, count)
+			return fmt.Errorf("dispatcher: generator returned nil transaction (batch %d/%d)", i+1, count)
 		}
 		// Send the transaction
 		if err := d.sender.Send(ctx, tx); err != nil {

--- a/stats/logger.go
+++ b/stats/logger.go
@@ -111,8 +111,7 @@ func (l *Logger) logCurrentStats() {
 	}
 
 	// Print overall summary line
-	log.Printf("[%s] throughput tps=%.2f, txs=%d,  latency(avg=%v p50=%v p99=%v max=%v)",
-		time.Now().Format("15:04:05"),
+	log.Printf("throughput tps=%.2f, txs=%d,  latency(avg=%v p50=%v p99=%v max=%v)",
 		totalWindowTPS,
 		totalTxs,
 		overallAvgLatency.Round(time.Millisecond),
@@ -122,8 +121,7 @@ func (l *Logger) logCurrentStats() {
 
 	// Print block statistics if available
 	if stats.BlockStats != nil && stats.BlockStats.SampleCount > 0 {
-		log.Printf("[%s] %s",
-			time.Now().Format("15:04:05"),
+		log.Printf("%s",
 			stats.BlockStats.FormatBlockStats())
 	}
 

--- a/stats/user_latency_tracker.go
+++ b/stats/user_latency_tracker.go
@@ -2,18 +2,18 @@ package stats
 
 import (
 	"context"
-	"github.com/sei-protocol/sei-load/utils"
 	"log"
 	"math/big"
 	"sort"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/sei-protocol/sei-load/utils"
 )
 
 // UserLatencyTracker tracks user latency by analyzing block transactions
 type UserLatencyTracker struct {
-	endpoint string
 	interval time.Duration
 }
 
@@ -26,11 +26,8 @@ func NewUserLatencyTracker(interval time.Duration) *UserLatencyTracker {
 
 // Run starts the user latency tracking loop
 func (ult *UserLatencyTracker) Run(ctx context.Context, endpoint string) error {
-	ult.endpoint = endpoint
-
 	// Create ticker for the configured interval
 	ticker := time.NewTicker(ult.interval)
-	defer ticker.Stop()
 
 	// Connect to the endpoint
 	client, err := ethclient.Dial(endpoint)

--- a/stats/user_latency_tracker.go
+++ b/stats/user_latency_tracker.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"github.com/sei-protocol/sei-load/utils"
 	"log"
 	"math/big"
 	"sort"
@@ -39,14 +40,12 @@ func (ult *UserLatencyTracker) Run(ctx context.Context, endpoint string) error {
 	defer client.Close()
 
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if err := ult.trackLatency(ctx, client); err != nil {
-				log.Printf("User latency tracker: Error tracking latency: %v", err)
-				// Continue on error - don't stop the tracker
-			}
+		if _, err := utils.Recv(ctx, ticker.C); err != nil {
+			return err
+		}
+		if err := ult.trackLatency(ctx, client); err != nil {
+			log.Printf("User latency tracker: Error tracking latency: %v", err)
+			// Continue on error - don't stop the tracker
 		}
 	}
 }

--- a/stats/user_latency_tracker.go
+++ b/stats/user_latency_tracker.go
@@ -1,0 +1,111 @@
+package stats
+
+import (
+	"context"
+	"log"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// UserLatencyTracker tracks user latency by analyzing block transactions
+type UserLatencyTracker struct {
+	endpoint string
+	interval time.Duration
+}
+
+// NewUserLatencyTracker creates a new user latency tracker
+func NewUserLatencyTracker(interval time.Duration) *UserLatencyTracker {
+	return &UserLatencyTracker{
+		interval: interval,
+	}
+}
+
+// Run starts the user latency tracking loop
+func (ult *UserLatencyTracker) Run(ctx context.Context, endpoint string) error {
+	ult.endpoint = endpoint
+
+	// Create ticker for the configured interval
+	ticker := time.NewTicker(ult.interval)
+	defer ticker.Stop()
+
+	// Connect to the endpoint
+	client, err := ethclient.Dial(endpoint)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := ult.trackLatency(ctx, client); err != nil {
+				log.Printf("User latency tracker: Error tracking latency: %v", err)
+				// Continue on error - don't stop the tracker
+			}
+		}
+	}
+}
+
+// trackLatency fetches the latest block and calculates user latency statistics
+func (ult *UserLatencyTracker) trackLatency(ctx context.Context, client *ethclient.Client) error {
+	// Get the latest block with transactions
+	block, err := client.BlockByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// Skip if no transactions
+	txs := block.Transactions()
+	if len(txs) == 0 {
+		log.Printf("User latency tracker: Block %d has no transactions", block.NumberU64())
+		return nil
+	}
+
+	// Calculate latencies for each transaction
+	var latencies []time.Duration
+	blockTimestamp := time.Unix(int64(block.Time()), 0)
+
+	for i, tx := range txs {
+		// Extract timestamp from transaction value (set to time.Now().Unix() during creation)
+		if tx.Value() != nil && tx.Value().Cmp(big.NewInt(0)) > 0 {
+			txTimestamp := time.Unix(tx.Value().Int64(), 0)
+			latency := blockTimestamp.Sub(txTimestamp)
+
+			// Only include positive latencies (sanity check)
+			if latency >= 0 {
+				latencies = append(latencies, latency)
+			} else {
+				log.Printf("User latency tracker: Negative latency detected: %v", latency)
+			}
+		} else {
+			log.Printf("User latency tracker: TX %d has nil or zero value", i)
+		}
+	}
+
+	// Skip logging if no valid latencies
+	if len(latencies) == 0 {
+		log.Printf("User latency tracker: No valid latencies found in block %d", block.NumberU64())
+		return nil
+	}
+
+	// Calculate statistics
+	sort.Slice(latencies, func(i, j int) bool {
+		return latencies[i] < latencies[j]
+	})
+
+	minLatency := latencies[0]
+	maxLatency := latencies[len(latencies)-1]
+	p50 := latencies[len(latencies)/2]
+
+	// Log the summary
+	log.Printf("user latency height=%d txs=%d min=%v p50=%v max=%v",
+		block.NumberU64(), len(latencies),
+		minLatency, p50, maxLatency)
+
+	return nil
+}

--- a/utils/mutex.go
+++ b/utils/mutex.go
@@ -49,7 +49,7 @@ type atomicWatch[T any] struct {
 }
 
 type AtomicSend[T any] struct {
-	*atomicWatch[T]
+	atomicWatch[T]
 }
 
 // Store updates the value of the atomic watch.
@@ -67,14 +67,13 @@ func (w *AtomicSend[T]) Update(f func(T) (T, bool)) {
 }
 
 func NewAtomicSend[T any](value T) (w AtomicSend[T]) {
-	w.atomicWatch = &atomicWatch[T]{}
 	w.ptr.Store(newVersion(value))
 	// nolint:nakedret
 	return
 }
 
 func (w *AtomicSend[T]) Subscribe() AtomicRecv[T] {
-	return AtomicRecv[T]{w.atomicWatch}
+	return AtomicRecv[T]{&w.atomicWatch}
 }
 
 // AtomicWatch stores a pointer to an IMMUTABLE value.
@@ -82,7 +81,7 @@ func (w *AtomicSend[T]) Subscribe() AtomicRecv[T] {
 // TODO(gprusak): remove mutex and rename to AtomicSend,
 // this will allow for sharing a mutex across multiple AtomicSenders.
 type AtomicWatch[T any] struct {
-	*atomicWatch[T]
+	atomicWatch[T]
 	mu sync.Mutex
 }
 
@@ -98,7 +97,7 @@ func NewAtomicWatch[T any](value T) (w AtomicWatch[T]) {
 
 // Subscribe returns a view-only API of the atomic watch.
 func (w *AtomicWatch[T]) Subscribe() AtomicRecv[T] {
-	return AtomicRecv[T]{w.atomicWatch}
+	return AtomicRecv[T]{&w.atomicWatch}
 }
 
 // Load returns the current value of the atomic watch.
@@ -232,12 +231,4 @@ func (w *Watch[T]) Lock() iter.Seq2[T, *WatchCtrl] {
 		defer w.ctrl.mu.Unlock()
 		_ = yield(w.val, &w.ctrl)
 	}
-}
-
-// Set updates the value and notifies all watchers
-func (w *Mutex[T]) Set(value T) {
-	newVersion := newVersion(value)
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.value = newVersion.value
 }


### PR DESCRIPTION
Notes:
- New flag `--track-user-latency` will track user latency metrics.  
- It samples the latest block every `--stats-interval` and calculates the latency in that block.  
- The latency is the block timestamp minus the value in the tx (value is set to time in epoch).  
- The resolution here is seconds because block timestamps are in seconds.  In general if our timing is subsecond we're okay.  
- A lower `--buffer-size` can keep this lower. 
- If this value is high, it could be that things are sitting in the mempool longer than they should.

```
2025/08/04 09:37:18 ============================================================
2025/08/04 09:37:28 throughput tps=152.30, txs=1523,  latency(avg=7ms p50=4ms p99=32ms max=87ms)
2025/08/04 09:37:29 user latency height=6908 txs=21 min=0s p50=0s max=0s
2025/08/04 09:37:38 throughput tps=104.40, txs=2567,  latency(avg=10ms p50=6ms p99=33ms max=111ms)
2025/08/04 09:37:38 user latency height=6940 txs=57 min=0s p50=0s max=0s
2025/08/04 09:37:48 throughput tps=166.30, txs=4230,  latency(avg=6ms p50=5ms p99=30ms max=111ms)
2025/08/04 09:37:48 user latency height=6977 txs=15 min=1s p50=1s max=1s
```