### PR TITLE
Use consistent go version across module and CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,19 +12,19 @@ jobs:
     
     strategy:
       matrix:
-        go-version: [1.24.1]
+        go-version: [1.24.5]
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     
     - name: Cache Go modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build


### PR DESCRIPTION
Use a consistent go minor version across go mod and CI workflow.

While at it, upgrade to the latest GitHub Actions steps for Go setup and cache.