### PR TITLE
Containerize `seiload` and publish to GHCR

### DIFF
--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -1,0 +1,54 @@
+name: Container
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to publish'
+        required: true
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-checkout.outputs.ref }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+            type=sha,format=long
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.24.5-bullseye AS build
+
+WORKDIR /go/src/sei-load
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /go/bin/seiload ./
+
+FROM gcr.io/distroless/base
+COPY --from=build /go/bin/seiload /usr/bin/
+
+ENTRYPOINT ["/usr/bin/seiload"]


### PR DESCRIPTION
Containerize the `seiload` CLI and add GitHub Actions workflow to build the container in PRs and publish on merges to `main`, along with adhoc workflow dispatch by commit SHA for experimental work/debugging on non-main branches.