### PR TITLE
Consistently use `testify` for test assertions

### DIFF
--- a/utils/service/parallel_test.go
+++ b/utils/service/parallel_test.go
@@ -3,11 +3,13 @@ package service
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelOk(t *testing.T) {
 	x := [10]int{}
-	if err := Parallel(func(s ParallelScope) error {
+	err := Parallel(func(s ParallelScope) error {
 		for i := range x {
 			s.Spawn(func() error {
 				x[i] = i
@@ -15,13 +17,10 @@ func TestParallelOk(t *testing.T) {
 			})
 		}
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 	for want, got := range x {
-		if want != got {
-			t.Fatalf("x[%d] = %d, want %d", want, got, want)
-		}
+		require.Equal(t, want, got, "x[%d] = %d, want %d", want, got, want)
 	}
 }
 
@@ -40,15 +39,11 @@ func TestParallelFail(t *testing.T) {
 		}
 		return nil
 	})
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("err = %v, want %v", err, wantErr)
-	}
+	require.ErrorIs(t, wantErr, err, "err = %v, want %v", err, wantErr)
 	for want, got := range x {
 		if want%2 == 0 {
 			want = 0
 		}
-		if want != got {
-			t.Fatalf("x[%d] = %d, want %d", want, got, want)
-		}
+		require.Equal(t, want, got, "x[%d] = %d, want %d", want, got, want)
 	}
 }

--- a/utils/wait_test.go
+++ b/utils/wait_test.go
@@ -4,20 +4,16 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSON(t *testing.T) {
 	var got, want struct{ X Duration }
 	want.X = Duration(100 * time.Millisecond)
 	j, err := json.Marshal(want)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("%s", j)
-	if err := json.Unmarshal(j, &got); err != nil {
-		t.Fatal(err)
-	}
-	if err := TestDiff(want, got); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, json.Unmarshal(j, &got))
+	require.NoError(t, TestDiff(want, got))
 }


### PR DESCRIPTION
This repo already has a dependency to `stretchr/testify`. Use it consistently across all tests.

Separately, improve temporary file creation using `t.TempDir`, which would automatically clean up the files after test ends.