### PR TITLE
Tag all metrics by Sei chain ID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,9 @@ import (
 
 // LoadConfig stores the configuration for load-related settings.
 type LoadConfig struct {
-	ChainID    int64          `json:"chainId,omitempty"`
+	ChainID int64 `json:"chainId,omitempty"`
+	// SeiChainID is the textual chain ID used for tagging metric collection.
+	SeiChainID string         `json:"seiChainID,omitempty"`
 	Endpoints  []string       `json:"endpoints"`
 	Accounts   *AccountConfig `json:"accounts,omitempty"`
 	Scenarios  []Scenario     `json:"scenarios,omitempty"`

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 		// Create and start block collector if endpoints are available
 		var blockCollector *stats.BlockCollector
 		if len(cfg.Endpoints) > 0 && settings.TrackBlocks {
-			blockCollector = stats.NewBlockCollector()
+			blockCollector = stats.NewBlockCollector(cfg.SeiChainID)
 			collector.SetBlockCollector(blockCollector)
 			s.SpawnBgNamed("block collector", func() error {
 				return blockCollector.Run(ctx, cfg.Endpoints[0])

--- a/profiles/loadtest_default.json
+++ b/profiles/loadtest_default.json
@@ -1,5 +1,6 @@
 {
     "chainId": 713714,
+    "seiChainId": "loadtest-default",
     "endpoints": [
       "http://127.0.0.1:8545"
     ],

--- a/profiles/local.json
+++ b/profiles/local.json
@@ -1,5 +1,6 @@
 {
   "chainId": 713714,
+  "seiChainId": "loadtest-local",
   "endpoints": [
     "http://127.0.0.1:8545"
   ],

--- a/sender/metrics.go
+++ b/sender/metrics.go
@@ -40,7 +40,7 @@ var (
 					observer.Observe(int64(worker.GetChannelLength()), metric.WithAttributes(
 						attribute.String("endpoint", worker.GetEndpoint()),
 						attribute.Int("worker_id", worker.id),
-						attribute.Int64("chain_id", worker.chainID),
+						attribute.String("chain_id", worker.seiChainID),
 					))
 				}
 				return nil
@@ -54,7 +54,7 @@ type chainWorkerObserver struct {
 }
 type chainWorkerID struct {
 	workerID int
-	chainID  int64
+	chainID  string
 }
 
 func meterWorkerQueueLength(worker *Worker) {
@@ -62,7 +62,7 @@ func meterWorkerQueueLength(worker *Worker) {
 	defer meteredChainWorkers.lock.Unlock()
 	id := chainWorkerID{
 		workerID: worker.id,
-		chainID:  worker.chainID,
+		chainID:  worker.seiChainID,
 	}
 	if _, exists := meteredChainWorkers.workers[id]; !exists {
 		meteredChainWorkers.workers[id] = worker

--- a/sender/sharded_sender.go
+++ b/sender/sharded_sender.go
@@ -34,7 +34,7 @@ func NewShardedSender(cfg *config.LoadConfig, bufferSize int, workers int, limit
 
 	workerList := make([]*Worker, len(cfg.Endpoints))
 	for i, endpoint := range cfg.Endpoints {
-		workerList[i] = NewWorker(i, cfg.ChainID, endpoint, bufferSize, workers, limiter)
+		workerList[i] = NewWorker(i, cfg.SeiChainID, endpoint, bufferSize, workers, limiter)
 	}
 
 	return &ShardedSender{

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -26,7 +26,7 @@ import (
 // Worker handles sending transactions to a specific endpoint
 type Worker struct {
 	id            int
-	chainID       int64
+	seiChainID    string
 	endpoint      string
 	txChan        chan *types.LoadTx
 	sentTxs       chan *types.LoadTx
@@ -58,10 +58,10 @@ func newHttpClient() *http.Client {
 }
 
 // NewWorker creates a new worker for a specific endpoint
-func NewWorker(id int, chainID int64, endpoint string, bufferSize int, workers int, limiter *rate.Limiter) *Worker {
+func NewWorker(id int, seiChainID string, endpoint string, bufferSize int, workers int, limiter *rate.Limiter) *Worker {
 	w := &Worker{
 		id:            id,
-		chainID:       chainID,
+		seiChainID:    seiChainID,
 		endpoint:      endpoint,
 		txChan:        make(chan *types.LoadTx, bufferSize),
 		sentTxs:       make(chan *types.LoadTx, bufferSize),
@@ -140,7 +140,7 @@ func (w *Worker) waitForReceipt(ctx context.Context, eth *ethclient.Client, tx *
 				attribute.String("scenario", tx.Scenario.Name),
 				attribute.String("endpoint", w.endpoint),
 				attribute.Int("worker_id", w.id),
-				attribute.Int64("chain_id", w.chainID),
+				attribute.String("chain_id", w.seiChainID),
 				statusAttrFromError(_err)),
 		)
 	}(time.Now())
@@ -206,7 +206,7 @@ func (w *Worker) sendTransaction(ctx context.Context, client *http.Client, tx *t
 				attribute.String("scenario", tx.Scenario.Name),
 				attribute.String("endpoint", w.endpoint),
 				attribute.Int("worker_id", w.id),
-				attribute.Int64("chain_id", w.chainID),
+				attribute.String("chain_id", w.seiChainID),
 				statusAttrFromError(_err)),
 		)
 	}(time.Now())


### PR DESCRIPTION
Use the textual Sei chain ID to tag all metrics, because it is human-readable and consistent with the current monitoring infra.