### PR TITLE
Add ramping loadtests to test cluster 

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -20,6 +20,7 @@ type Settings struct {
 	TrackBlocks      bool          `json:"trackBlocks"`
 	TrackUserLatency bool          `json:"trackUserLatency"`
 	Prewarm          bool          `json:"prewarm"`
+	RampUp           bool          `json:"rampUp"`
 }
 
 // DefaultSettings returns the default configuration values
@@ -35,6 +36,7 @@ func DefaultSettings() Settings {
 		TrackBlocks:      false,
 		TrackUserLatency: false,
 		Prewarm:          false,
+		RampUp:           false,
 	}
 }
 
@@ -52,6 +54,7 @@ func InitializeViper(cmd *cobra.Command) error {
 		"prewarm":          "prewarm",
 		"trackUserLatency": "track-user-latency",
 		"workers":          "workers",
+		"rampUp":           "ramp-up",
 	}
 
 	for viperKey, flagName := range flagBindings {
@@ -72,7 +75,7 @@ func InitializeViper(cmd *cobra.Command) error {
 	viper.SetDefault("prewarm", defaults.Prewarm)
 	viper.SetDefault("trackUserLatency", defaults.TrackUserLatency)
 	viper.SetDefault("workers", defaults.Workers)
-
+	viper.SetDefault("rampUp", defaults.RampUp)
 	return nil
 }
 
@@ -103,5 +106,6 @@ func ResolveSettings() Settings {
 		TrackBlocks:      viper.GetBool("trackBlocks"),
 		TrackUserLatency: viper.GetBool("trackUserLatency"),
 		Prewarm:          viper.GetBool("prewarm"),
+		RampUp:           viper.GetBool("rampUp"),
 	}
 }

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -90,6 +90,7 @@ func TestArgumentPrecedence(t *testing.T) {
 			cmd.Flags().Bool("prewarm", false, "Prewarm")
 			cmd.Flags().Bool("track-user-latency", false, "Track user latency")
 			cmd.Flags().Int("buffer-size", 0, "Buffer size")
+			cmd.Flags().Bool("ramp-up", false, "Ramp up loadtest")
 
 			// Parse CLI args
 			if len(tt.cliArgs) > 0 {
@@ -128,6 +129,7 @@ func TestDefaultSettings(t *testing.T) {
 		TrackBlocks:      false,
 		TrackUserLatency: false,
 		Prewarm:          false,
+		RampUp:           false,
 	}
 
 	if defaults != expected {

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 	// Create statistics collector and logger
 	collector := stats.NewCollector()
 	logger := stats.NewLogger(collector, settings.StatsInterval, settings.Debug)
+	var ramper *sender.Ramper
 
 	err = service.Run(ctx, func(ctx context.Context, s service.Scope) error {
 		// Create the generator from the config struct
@@ -189,7 +190,7 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 				return ramperBlockCollector.Run(ctx, cfg.Endpoints[0])
 			})
 
-			ramper := sender.NewRamper(&sender.RamperConfig{
+			ramper = sender.NewRamper(&sender.RamperConfig{
 				IncrementTps: 100,
 				LoadTime:     120 * time.Second,
 				PauseTime:    30 * time.Second,
@@ -287,6 +288,9 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 	})
 	// Print final statistics
 	logger.LogFinalStats()
+	if settings.RampUp && ramper != nil {
+		ramper.LogFinalStats()
+	}
 	log.Printf("👋 Shutdown complete")
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -190,11 +190,11 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 				return ramperBlockCollector.Run(ctx, cfg.Endpoints[0])
 			})
 
-			ramper = sender.NewRamper(&sender.RamperConfig{
-				IncrementTps: 100,
-				LoadTime:     120 * time.Second,
-				PauseTime:    30 * time.Second,
-			}, ramperBlockCollector, sharedLimiter)
+			ramper = sender.NewRamper(
+				sender.NewRampCurveStep(100, 100, 30*time.Second, 10*time.Second),
+				ramperBlockCollector,
+				sharedLimiter,
+			)
 			s.SpawnBgNamed("ramper", func() error { return ramper.Run(ctx) })
 		}
 

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 			})
 
 			ramper = sender.NewRamper(
-				sender.NewRampCurveStep(100, 100, 30*time.Second, 10*time.Second),
+				sender.NewRampCurveStep(100, 100, 120*time.Second, 30*time.Second),
 				ramperBlockCollector,
 				sharedLimiter,
 			)

--- a/main.go
+++ b/main.go
@@ -191,8 +191,8 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 
 			ramper := sender.NewRamper(&sender.RamperConfig{
 				IncrementTps: 100,
-				LoadTime:     30 * time.Second, // TODO: update
-				PauseTime:    10 * time.Second,
+				LoadTime:     120 * time.Second,
+				PauseTime:    30 * time.Second,
 			}, ramperBlockCollector, sharedLimiter)
 			s.SpawnBgNamed("ramper", func() error { return ramper.Run(ctx) })
 		}

--- a/profiles/evm_transfer.json
+++ b/profiles/evm_transfer.json
@@ -1,0 +1,26 @@
+{
+    "chainId": 713714,
+    "endpoints": [
+      "http://127.0.0.1:8545"
+    ],
+    "accounts": {
+      "count": 5000,
+      "newAccountRate": 1
+    },
+    "scenarios": [
+      {
+        "name": "EVMTransfer",
+        "weight": 1
+      }
+    ],
+    "workers": 1,
+    "tps": 0,
+    "statsInterval": "5s",
+    "bufferSize": 1000,
+    "dryRun": false,
+    "debug": false,
+    "trackReceipts": false,
+    "trackBlocks": false,
+    "trackUserLatency": false,
+    "prewarm": false
+  }

--- a/profiles/evm_transfer.json
+++ b/profiles/evm_transfer.json
@@ -1,5 +1,6 @@
 {
     "chainId": 713714,
+    "seiChainId": "sei-chain",
     "endpoints": [
       "http://127.0.0.1:8545"
     ],

--- a/profiles/evm_transfer.json
+++ b/profiles/evm_transfer.json
@@ -5,7 +5,7 @@
     ],
     "accounts": {
       "count": 5000,
-      "newAccountRate": 1
+      "newAccountRate": 0.0
     },
     "scenarios": [
       {

--- a/profiles/local_docker.json
+++ b/profiles/local_docker.json
@@ -1,0 +1,46 @@
+{
+  "chainId": 713714,
+  "seiChainId": "local-docker",
+  "endpoints": [
+    "http://127.0.0.1:8545",
+    "http://127.0.0.1:8547",
+    "http://127.0.0.1:8549",
+    "http://127.0.0.1:8551"
+  ],
+  "accounts": {
+    "count": 5000,
+    "newAccountRate": 0.0
+  },
+  "scenarios": [
+    {
+      "name": "ERC20",
+      "weight": 1
+    },
+    {
+      "name": "EVMTransfer",
+      "weight": 1
+    },
+    {
+      "name": "ERC20Noop",
+      "weight": 1
+    },
+    {
+      "name": "ERC20Conflict",
+      "weight": 1
+    },
+    {
+      "name": "ERC721",
+      "weight": 1
+    }
+  ],
+  "workers": 1,
+  "tps": 0,
+  "statsInterval": "5s",
+  "bufferSize": 1000,
+  "dryRun": false,
+  "debug": false,
+  "trackReceipts": false,
+  "trackBlocks": false,
+  "trackUserLatency": false,
+  "prewarm": false
+}

--- a/profiles/local_docker.json
+++ b/profiles/local_docker.json
@@ -15,22 +15,6 @@
     {
       "name": "ERC20",
       "weight": 1
-    },
-    {
-      "name": "EVMTransfer",
-      "weight": 1
-    },
-    {
-      "name": "ERC20Noop",
-      "weight": 1
-    },
-    {
-      "name": "ERC20Conflict",
-      "weight": 1
-    },
-    {
-      "name": "ERC721",
-      "weight": 1
     }
   ],
   "workers": 1,

--- a/sender/ramper.go
+++ b/sender/ramper.go
@@ -1,0 +1,112 @@
+package sender
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/sei-protocol/sei-load/stats"
+	"github.com/sei-protocol/sei-load/utils/service"
+	"golang.org/x/time/rate"
+)
+
+// This will manage the ramping process for the loadtest
+// Ramping loadtest will being at the StartTps and spend LoadTime at each step, ending when we violate the chain SLO of
+// 1 block per second over a given ramp period (as measured in the back half of the ramp time)
+// If we successfully pass a given TPS, we will pause for PauseTime, and then start the next step.
+// If we fail to pass a given TPS, we will stop the loadtest.
+
+type RamperConfig struct {
+	IncrementTps float64
+	LoadTime     time.Duration
+	PauseTime    time.Duration
+}
+
+type Ramper struct {
+	sharedLimiter  *rate.Limiter
+	cfg            *RamperConfig
+	blockCollector *stats.BlockCollector
+	currentTps     float64
+	step           int
+	startTime      time.Time
+	stopTime       time.Time
+}
+
+func NewRamper(cfg *RamperConfig, blockCollector *stats.BlockCollector, sharedLimiter *rate.Limiter) *Ramper {
+	sharedLimiter.SetLimit(rate.Limit(0)) // reset limiter to 0
+	return &Ramper{
+		sharedLimiter:  sharedLimiter,
+		cfg:            cfg,
+		blockCollector: blockCollector,
+		currentTps:     0,
+		step:           0,
+		startTime:      time.Now(),
+		stopTime:       time.Time{},
+	}
+}
+
+func (r *Ramper) NewStep() error {
+	r.step++
+	r.currentTps = r.cfg.IncrementTps * float64(r.step)
+	r.sharedLimiter.SetLimit(rate.Limit(r.currentTps))
+	r.startTime = time.Now()
+	log.Printf("📈 Ramping to step %d with TPS %f for %v", r.step, r.currentTps, r.cfg.LoadTime)
+	return nil
+}
+
+// For ramping loadtest SLO, we'll look at the block time p50, if this increases beyond 1s, we consider it an uptime failure
+func (r *Ramper) WatchSLO(ctx context.Context) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		// reset blockCollector window
+		defer close(ch)
+		r.blockCollector.ResetWindowStats()
+		time.Sleep(r.cfg.LoadTime / 2) // wait before checking SLO
+		// wait for half of the load time
+		log.Println("🔍 Ramping watching chain SLO")
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// we need to watch the monitoring endpoint for the SLO
+				// Add appropriate monitoring logic here with timeout/context respect
+				// check window stats
+				windowStats := r.blockCollector.GetWindowBlockStats()
+				if windowStats.P50BlockTime > 1*time.Second {
+					ch <- struct{}{}
+				}
+				time.Sleep(200 * time.Millisecond) // TODO: maybe this is too frequent?
+				continue
+			}
+		}
+	}()
+	return ch
+}
+
+// Start initializes and starts all workers
+func (r *Ramper) Run(ctx context.Context) error {
+	return service.Run(ctx, func(ctx context.Context, s service.Scope) error {
+		// TODO: Implement ramping logic
+		for {
+			r.NewStep()
+			loadTimer := time.After(r.cfg.LoadTime)
+			sloChan := r.WatchSLO(ctx)
+			select {
+			case <-sloChan:
+				r.sharedLimiter.SetLimit(rate.Limit(1))
+				log.Printf("❌ Ramping failed to pass SLO, stopping loadtest, failure window blockstats:")
+				log.Printf("🔍 Block stats: %s", r.blockCollector.GetWindowBlockStats().FormatBlockStats())
+				return errors.New("Ramp Test failed SLO")
+			case <-loadTimer:
+				r.sharedLimiter.SetLimit(rate.Limit(1)) // set limit to 1 to "pause" load
+				log.Printf("✅ Ramping passed current step, sleeping for %v", r.cfg.PauseTime)
+				log.Printf("🔍 Block stats: %s", r.blockCollector.GetWindowBlockStats().FormatBlockStats())
+				time.Sleep(r.cfg.PauseTime)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+}

--- a/sender/ramper.go
+++ b/sender/ramper.go
@@ -73,8 +73,7 @@ func (r *Ramper) WatchSLO(ctx context.Context) <-chan struct{} {
 				// we need to watch the monitoring endpoint for the SLO
 				// Add appropriate monitoring logic here with timeout/context respect
 				// check window stats
-				windowStats := r.blockCollector.GetWindowBlockStats()
-				if windowStats.P50BlockTime > 1*time.Second {
+				if r.blockCollector.GetWindowBlockTimePercentile(90) > 1*time.Second {
 					ch <- struct{}{}
 				}
 				time.Sleep(200 * time.Millisecond) // TODO: maybe this is too frequent?

--- a/sender/ramper.go
+++ b/sender/ramper.go
@@ -71,13 +71,12 @@ func NewRamper(cfg *RamperConfig, blockCollector stats.BlockStatsProvider, share
 	}
 }
 
-func (r *Ramper) NewStep() error {
+func (r *Ramper) NewStep() {
 	r.step++
 	r.currentTps = r.cfg.IncrementTps * float64(r.step)
 	r.sharedLimiter.SetLimit(rate.Limit(r.currentTps))
 	r.startTime = time.Now()
 	log.Printf("📈 Ramping to step %d with TPS %f for %v", r.step, r.currentTps, r.cfg.LoadTime)
-	return nil
 }
 
 func (r *Ramper) LogFinalStats() {

--- a/sender/ramper.go
+++ b/sender/ramper.go
@@ -34,16 +34,16 @@ type RampStats struct {
 
 func (r RampStats) FormatRampStats() string {
 	return fmt.Sprintf(`
-┌─────────────────────────────────────────┐
-│              RAMP STATISTICS            │
-├─────────────────────────────────────────┤
-│ Step:       %d                          │
-│ Target TPS: %.2f                        │
-│ Sent Txs:   %d                          │
-├─────────────────────────────────────────┤
-│ Window Block Stats:                     │
-│ %s                                      │
-└─────────────────────────────────────────┘`,
+─────────────────────────────────────────
+              RAMP STATISTICS
+─────────────────────────────────────────
+ Step:       %d
+ Target TPS: %.2f
+ Sent Txs:   %d
+─────────────────────────────────────────
+ Window Block Stats:
+ %s
+─────────────────────────────────────────`,
 		r.Step, r.TargetTPS, r.SentTxs, r.WindowBlockStats.FormatBlockStats())
 }
 
@@ -124,7 +124,7 @@ func (r *Ramper) Run(ctx context.Context) error {
 				r.sharedLimiter.SetLimit(rate.Limit(1))
 				log.Printf("❌ Ramping failed to pass SLO, stopping loadtest, failure window blockstats:")
 				log.Printf("🔍 Block stats: %s", r.blockCollector.GetWindowBlockStats().FormatBlockStats())
-				return errors.New("Ramp Test failed SLO")
+				return errors.New("Ramp Test failed SLO\n" + r.latestStats.FormatRampStats())
 			case <-loadTimer:
 				r.sharedLimiter.SetLimit(rate.Limit(1)) // set limit to 1 to "pause" load
 				log.Printf("✅ Ramping passed current step, sleeping for %v", r.cfg.PauseTime)

--- a/sender/ramper.go
+++ b/sender/ramper.go
@@ -62,7 +62,6 @@ func (r *Ramper) WatchSLO(ctx context.Context) <-chan struct{} {
 		// reset blockCollector window
 		defer close(ch)
 		r.blockCollector.ResetWindowStats()
-		time.Sleep(r.cfg.LoadTime / 2) // wait before checking SLO
 		// wait for half of the load time
 		log.Println("🔍 Ramping watching chain SLO")
 		for {

--- a/sender/ramper_test.go
+++ b/sender/ramper_test.go
@@ -37,22 +37,14 @@ func TestRamper_NewStep_LimiterUpdate(t *testing.T) {
 	}
 
 	// Call NewStep and verify limit is updated correctly
-	err := ramper.NewStep()
-	if err != nil {
-		t.Fatalf("NewStep failed: %v", err)
-	}
-
+	ramper.NewStep()
 	expectedTps := 50.0 // incrementTps * 1 (first step)
 	if limiter.Limit() != rate.Limit(expectedTps) {
 		t.Fatalf("Expected TPS %v after first step, got %v", expectedTps, limiter.Limit())
 	}
 
 	// Call NewStep again and verify increment
-	err = ramper.NewStep()
-	if err != nil {
-		t.Fatalf("Second NewStep failed: %v", err)
-	}
-
+	ramper.NewStep()
 	expectedTps = 100.0 // incrementTps * 2 (second step)
 	if limiter.Limit() != rate.Limit(expectedTps) {
 		t.Fatalf("Expected TPS %v after second step, got %v", expectedTps, limiter.Limit())

--- a/sender/ramper_test.go
+++ b/sender/ramper_test.go
@@ -1,0 +1,162 @@
+package sender
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sei-protocol/sei-load/stats"
+	"golang.org/x/time/rate"
+)
+
+func TestRamper_NewStep_LimiterUpdate(t *testing.T) {
+	// Create a limiter with non-zero initial rate
+	initialRate := rate.Limit(100.0)
+	limiter := rate.NewLimiter(initialRate, 1)
+
+	// Verify initial rate is set
+	if limiter.Limit() != initialRate {
+		t.Fatalf("Expected initial rate %v, got %v", initialRate, limiter.Limit())
+	}
+
+	// Create ramper config
+	cfg := &RamperConfig{
+		IncrementTps: 50.0,
+		LoadTime:     2 * time.Second,
+		PauseTime:    1 * time.Second,
+	}
+
+	blockCollector := stats.NewBlockCollector("loadtest-local")
+	// Create ramper - should reset limiter to 0
+	ramper := NewRamper(cfg, blockCollector, limiter)
+
+	// Verify limiter was reset to 0
+	if limiter.Limit() != 0 {
+		t.Fatalf("Expected limiter to be reset to 0, got %v", limiter.Limit())
+	}
+
+	// Call NewStep and verify limit is updated correctly
+	err := ramper.NewStep()
+	if err != nil {
+		t.Fatalf("NewStep failed: %v", err)
+	}
+
+	expectedTps := 50.0 // incrementTps * 1 (first step)
+	if limiter.Limit() != rate.Limit(expectedTps) {
+		t.Fatalf("Expected TPS %v after first step, got %v", expectedTps, limiter.Limit())
+	}
+
+	// Call NewStep again and verify increment
+	err = ramper.NewStep()
+	if err != nil {
+		t.Fatalf("Second NewStep failed: %v", err)
+	}
+
+	expectedTps = 100.0 // incrementTps * 2 (second step)
+	if limiter.Limit() != rate.Limit(expectedTps) {
+		t.Fatalf("Expected TPS %v after second step, got %v", expectedTps, limiter.Limit())
+	}
+}
+
+func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
+	limiter := rate.NewLimiter(0, 1)
+	cfg := &RamperConfig{
+		IncrementTps: 50.0,
+		LoadTime:     2 * time.Second,
+		PauseTime:    1 * time.Second,
+	}
+
+	blockCollector := stats.NewBlockCollector("loadtest-local")
+	ramper := NewRamper(cfg, blockCollector, limiter)
+
+	// Set TPS below threshold first
+	ramper.currentTps = 400.0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Start watching SLO
+	sloChan := ramper.WatchSLO(ctx)
+
+	// Give it a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Update TPS to exceed threshold (>500)
+	ramper.currentTps = 600.0
+
+	// Wait for channel signal
+	select {
+	case <-sloChan:
+		// Expected behavior - SLO violation detected
+	case <-time.After(3 * time.Second):
+		t.Fatal("Expected SLO violation signal but timeout occurred")
+	}
+}
+
+func TestRamper_Run_StepProgression(t *testing.T) {
+	limiter := rate.NewLimiter(0, 1)
+	cfg := &RamperConfig{
+		IncrementTps: 50.0,
+		LoadTime:     2 * time.Second,
+		PauseTime:    1 * time.Second,
+	}
+
+	blockCollector := stats.NewBlockCollector("loadtest-local")
+	ramper := NewRamper(cfg, blockCollector, limiter)
+
+	// Create a context with timeout to prevent infinite running
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	// Track the progression
+	startTime := time.Now()
+
+	// Run in goroutine so we can monitor behavior
+	done := make(chan error, 1)
+	go func() {
+		done <- ramper.Run(ctx)
+	}()
+
+	// Wait a bit to let first step start
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that first step started (TPS should be 50)
+	if limiter.Limit() != rate.Limit(50.0) {
+		t.Fatalf("Expected first step TPS 50, got %v", limiter.Limit())
+	}
+
+	// Wait for load time to pass (2s) plus some buffer
+	time.Sleep(2000 * time.Millisecond)
+
+	// Should be in pause phase (limiter set to 1	)
+	if limiter.Limit() != rate.Limit(1) {
+		t.Fatalf("Expected limiter to be 1 during pause, got %v", limiter.Limit())
+	}
+
+	// Wait for pause time (1s) to start next step
+	time.Sleep(1000 * time.Millisecond)
+
+	// Should be in second step (TPS should be 100)
+	if limiter.Limit() != rate.Limit(100.0) {
+		t.Fatalf("Expected second step TPS 100, got %v", limiter.Limit())
+	}
+
+	// Cancel context to stop the run
+	cancel()
+
+	// Wait for completion
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("Expected context.Canceled error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not complete within timeout")
+	}
+
+	// Verify total time is reasonable (should be around 6+ seconds for our test)
+	totalTime := time.Since(startTime)
+	if totalTime < 3*time.Second {
+		t.Fatalf("Test completed too quickly (%v), expected at least 3 seconds", totalTime)
+	}
+}

--- a/sender/ramper_test.go
+++ b/sender/ramper_test.go
@@ -58,40 +58,37 @@ func TestRamper_NewStep_LimiterUpdate(t *testing.T) {
 	}
 }
 
-func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
-	limiter := rate.NewLimiter(0, 1)
-	cfg := &RamperConfig{
-		IncrementTps: 50.0,
-		LoadTime:     2 * time.Second,
-		PauseTime:    1 * time.Second,
-	}
+// func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
+// 	limiter := rate.NewLimiter(0, 1)
+// 	cfg := &RamperConfig{
+// 		IncrementTps: 50.0,
+// 		LoadTime:     2 * time.Second,
+// 		PauseTime:    1 * time.Second,
+// 	}
 
-	blockCollector := stats.NewBlockCollector("loadtest-local")
-	ramper := NewRamper(cfg, blockCollector, limiter)
+// blockCollector := stats.NewBlockCollector("loadtest-local")
+// ramper := NewRamper(cfg, blockCollector, limiter)
 
-	// Set TPS below threshold first
-	ramper.currentTps = 400.0
+// 	// Set TPS below threshold first
+// 	ramper.currentTps = 400.0
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+// 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+// 	defer cancel()
 
-	// Start watching SLO
-	sloChan := ramper.WatchSLO(ctx)
+// 	// Start watching SLO
+// 	sloChan := ramper.WatchSLO(ctx)
 
-	// Give it a moment to start
-	time.Sleep(100 * time.Millisecond)
+// 	// Give it a moment to start
+// 	time.Sleep(100 * time.Millisecond)
 
-	// Update TPS to exceed threshold (>500)
-	ramper.currentTps = 600.0
-
-	// Wait for channel signal
-	select {
-	case <-sloChan:
-		// Expected behavior - SLO violation detected
-	case <-time.After(3 * time.Second):
-		t.Fatal("Expected SLO violation signal but timeout occurred")
-	}
-}
+// 	// Wait for channel signal
+// 	select {
+// 	case <-sloChan:
+// 		// Expected behavior - SLO violation detected
+// 	case <-time.After(3 * time.Second):
+// 		t.Fatal("Expected SLO violation signal but timeout occurred")
+// 	}
+// }
 
 func TestRamper_Run_StepProgression(t *testing.T) {
 	limiter := rate.NewLimiter(0, 1)

--- a/sender/ramper_test.go
+++ b/sender/ramper_test.go
@@ -63,7 +63,7 @@ func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
 	mockBlockStats := stats.NewMockBlockStats()
 	ramper := NewRamper(cfg, mockBlockStats, limiter)
 
-	mockBlockStats.SetNextPercentile(90, 1100*time.Millisecond)
+	mockBlockStats.SetPercentile(90, 1100*time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -92,7 +92,7 @@ func TestRamper_Run_StepProgression(t *testing.T) {
 	}
 
 	mockBlockStats := stats.NewMockBlockStats()
-	mockBlockStats.SetNextPercentile(90, 500*time.Millisecond)
+	mockBlockStats.SetPercentile(90, 500*time.Millisecond)
 	ramper := NewRamper(cfg, mockBlockStats, limiter)
 
 	// Create a context with timeout to prevent infinite running
@@ -128,7 +128,7 @@ func TestRamper_Run_StepProgression(t *testing.T) {
 	if limiter.Limit() != rate.Limit(100.0) {
 		t.Fatalf("Expected second step TPS 100, got %v", limiter.Limit())
 	}
-	mockBlockStats.SetNextPercentile(90, 1100*time.Millisecond)
+	mockBlockStats.SetPercentile(90, 1100*time.Millisecond)
 
 	time.Sleep(100 * time.Millisecond)
 

--- a/sender/ramper_test.go
+++ b/sender/ramper_test.go
@@ -10,62 +10,51 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func TestRamper_NewStep_LimiterUpdate(t *testing.T) {
+func TestRamper_UpdateTPS_LimiterUpdate(t *testing.T) {
 	// Create a limiter with non-zero initial rate
 	initialRate := rate.Limit(100.0)
 	limiter := rate.NewLimiter(initialRate, 1)
 
 	// Verify initial rate is set
-	if limiter.Limit() != initialRate {
-		t.Fatalf("Expected initial rate %v, got %v", initialRate, limiter.Limit())
-	}
+	require.Equal(t, initialRate, limiter.Limit(), "Expected initial rate to be set correctly")
 
-	// Create ramper config
-	cfg := &RamperConfig{
-		IncrementTps: 50.0,
-		LoadTime:     2 * time.Second,
-		PauseTime:    1 * time.Second,
-	}
+	// Create ramp curve
+	rampCurve := NewRampCurveStep(50.0, 25.0, 2*time.Second, 1*time.Second)
+	blockCollector := stats.NewMockBlockStats()
 
-	blockCollector := stats.NewBlockCollector("loadtest-local")
 	// Create ramper - should reset limiter to 0
-	ramper := NewRamper(cfg, blockCollector, limiter)
+	ramper := NewRamper(rampCurve, blockCollector, limiter)
 
 	// Verify limiter was reset to 0
-	if limiter.Limit() != 0 {
-		t.Fatalf("Expected limiter to be reset to 0, got %v", limiter.Limit())
-	}
+	require.Equal(t, rate.Limit(1), limiter.Limit(), "Expected limiter to be reset to 1")
 
-	// Call NewStep and verify limit is updated correctly
-	ramper.NewStep()
-	expectedTps := 50.0 // incrementTps * 1 (first step)
-	if limiter.Limit() != rate.Limit(expectedTps) {
-		t.Fatalf("Expected TPS %v after first step, got %v", expectedTps, limiter.Limit())
-	}
+	ramper.startTime = time.Now() // simulate ramper starting
 
-	// Call NewStep again and verify increment
-	ramper.NewStep()
-	expectedTps = 100.0 // incrementTps * 2 (second step)
-	if limiter.Limit() != rate.Limit(expectedTps) {
-		t.Fatalf("Expected TPS %v after second step, got %v", expectedTps, limiter.Limit())
-	}
+	// Call UpdateTPS and verify limit is updated correctly (first step: 50 TPS)
+	ramper.UpdateTPS()
+	expectedTps := 50.0 // startTps for first step
+	require.Equal(t, rate.Limit(expectedTps), limiter.Limit(), "Expected TPS after first update")
+
+	// Simulate time passing to trigger next step (3 seconds = 1 cycle)
+	// Fast-forward the ramp curve by manipulating time
+	ramper.startTime = ramper.startTime.Add(-3 * time.Second) // Simulate 3 seconds ago
+
+	ramper.UpdateTPS()
+	expectedTps = 75.0 // startTps + incrementTps * 1 (second step)
+	require.Equal(t, rate.Limit(expectedTps), limiter.Limit(), "Expected TPS after second update")
 }
 
 func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
 
 	limiter := rate.NewLimiter(0, 1)
-	cfg := &RamperConfig{
-		IncrementTps: 50.0,
-		LoadTime:     2 * time.Second,
-		PauseTime:    1 * time.Second,
-	}
+	rampCurve := NewRampCurveStep(50.0, 25.0, 2*time.Second, 1*time.Second)
 
 	mockBlockStats := stats.NewMockBlockStats()
-	ramper := NewRamper(cfg, mockBlockStats, limiter)
+	ramper := NewRamper(rampCurve, mockBlockStats, limiter)
 
 	mockBlockStats.SetPercentile(90, 1100*time.Millisecond)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 	defer cancel()
 
 	sloChannel := ramper.WatchSLO(ctx)
@@ -74,8 +63,8 @@ func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
 	select {
 	case <-sloChannel:
 		// This is expected - SLO violation detected due to 1100ms > 1s threshold
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Expected SLO violation but timeout occurred")
+	case <-ctx.Done():
+		require.Fail(t, "Context cancelled before SLO violation was detected")
 	}
 
 	// Verify the channel is closed after violation
@@ -83,60 +72,116 @@ func TestRamper_WatchSLO_ChannelBehavior(t *testing.T) {
 	require.False(t, ok, "expected channel to be closed after violation")
 }
 
-func TestRamper_Run_StepProgression(t *testing.T) {
+func TestRamper_Run_TPSProgression(t *testing.T) {
 	limiter := rate.NewLimiter(0, 1)
-	cfg := &RamperConfig{
-		IncrementTps: 50.0,
-		LoadTime:     2 * time.Second,
-		PauseTime:    1 * time.Second,
-	}
+	// Create ramp curve: start at 50 TPS, increment by 25 TPS each step
+	// 2s load interval, 1s recovery interval (3s total cycle)
+	rampCurve := NewRampCurveStep(50.0, 25.0, 2*time.Second, 1*time.Second)
 
 	mockBlockStats := stats.NewMockBlockStats()
-	mockBlockStats.SetPercentile(90, 500*time.Millisecond)
-	ramper := NewRamper(cfg, mockBlockStats, limiter)
+	mockBlockStats.SetPercentile(90, 500*time.Millisecond) // Good SLO initially
+	ramper := NewRamper(rampCurve, mockBlockStats, limiter)
 
 	// Create a context with timeout to prevent infinite running
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 8*time.Second)
 	defer cancel()
 
 	// Run in goroutine so we can monitor behavior
 	done := make(chan error, 1)
 	go func() {
-		done <- ramper.Run(ctx)
+		select {
+		case done <- ramper.Run(ctx):
+		case <-ctx.Done():
+			require.Fail(t, "Context cancelled before SLO violation was detected")
+		}
 	}()
 
-	// Wait a bit to let first step start
-	time.Sleep(100 * time.Millisecond)
+	// Wait for ramper to start and update TPS
+	require.Eventually(t, func() bool {
+		return limiter.Limit() == rate.Limit(50.0)
+	}, 500*time.Millisecond, 10*time.Millisecond, "Expected first step TPS 50")
 
-	// Check that first step started (TPS should be 50)
-	if limiter.Limit() != rate.Limit(50.0) {
-		t.Fatalf("Expected first step TPS 50, got %v", limiter.Limit())
-	}
+	// Wait for load time to pass (2s) plus some buffer to enter recovery phase
+	require.Eventually(t, func() bool {
+		return limiter.Limit() == rate.Limit(1.0)
+	}, 3*time.Second, 50*time.Millisecond, "Expected limiter to be 1.0 during recovery")
 
-	// Wait for load time to pass (2s) plus some buffer
-	time.Sleep(2000 * time.Millisecond)
+	// Wait for recovery time (1s) to complete and start next step
+	require.Eventually(t, func() bool {
+		return limiter.Limit() == rate.Limit(75.0)
+	}, 1500*time.Millisecond, 50*time.Millisecond, "Expected second step TPS 75")
 
-	// Should be in pause phase (limiter set to 1	)
-	if limiter.Limit() != rate.Limit(1) {
-		t.Fatalf("Expected limiter to be 1 during pause, got %v", limiter.Limit())
-	}
-
-	// Wait for pause time (1s) to start next step
-	time.Sleep(1000 * time.Millisecond)
-
-	// Should be in second step (TPS should be 100)
-	if limiter.Limit() != rate.Limit(100.0) {
-		t.Fatalf("Expected second step TPS 100, got %v", limiter.Limit())
-	}
+	// Trigger SLO violation to test error handling
 	mockBlockStats.SetPercentile(90, 1100*time.Millisecond)
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for SLO violation to be detected
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, ErrRampTestFailedSLO, "expected SLO violation")
+			return true
+		case <-ctx.Done():
+			return false
+		default:
+			return false
+		}
+	}, 1*time.Second, 50*time.Millisecond, "Expected SLO violation to be detected")
+}
 
-	// expect SLO violation - err from done channel
-	select {
-	case err := <-done:
-		require.ErrorIs(t, err, ErrRampTestFailedSLO, "expected SLO violation")
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Expected SLO violation but timeout occurred")
-	}
+func TestRampCurveStep_GetTPS_FirstStep(t *testing.T) {
+	// Test the TPS calculation for the first step
+	rampCurve := NewRampCurveStep(100.0, 50.0, 3*time.Second, 2*time.Second)
+
+	// First step: should return 100 TPS (startTps)
+	tps := rampCurve.GetTPS(1 * time.Second) // Within first load interval
+	require.Equal(t, 100.0, tps, "First step should return startTps")
+
+	// Still in first step load interval
+	tps = rampCurve.GetTPS(2 * time.Second)
+	require.Equal(t, 100.0, tps, "Should still be in first step")
+}
+
+func TestRampCurveStep_GetTPS_RecoveryPhase(t *testing.T) {
+	rampCurve := NewRampCurveStep(100.0, 50.0, 3*time.Second, 2*time.Second)
+
+	// Recovery phase: should return 1.0 TPS
+	tps := rampCurve.GetTPS(4 * time.Second) // 3s load + 1s into recovery
+	require.Equal(t, 1.0, tps, "Recovery phase should return 1.0 TPS")
+
+	// End of recovery phase
+	tps = rampCurve.GetTPS(4999 * time.Millisecond) // 3s load + 2s recovery = end of first cycle
+	require.Equal(t, 1.0, tps, "End of recovery should still return 1.0 TPS")
+}
+
+func TestRampCurveStep_GetTPS_SecondStep(t *testing.T) {
+	rampCurve := NewRampCurveStep(100.0, 50.0, 3*time.Second, 2*time.Second)
+
+	// Second step: should return 150 TPS (100 + 50*1)
+	tps := rampCurve.GetTPS(6 * time.Second) // Start of second cycle (5s + 1s)
+	require.Equal(t, 150.0, tps, "Second step should return startTps + incrementTps")
+
+	// Still in second step load interval
+	tps = rampCurve.GetTPS(7 * time.Second)
+	require.Equal(t, 150.0, tps, "Should still be in second step")
+}
+
+func TestRampCurveStep_GetTPS_ThirdStepAndRecovery(t *testing.T) {
+	rampCurve := NewRampCurveStep(100.0, 50.0, 3*time.Second, 2*time.Second)
+
+	// Third step: should return 200 TPS (100 + 50*2)
+	tps := rampCurve.GetTPS(11 * time.Second) // Start of third cycle (10s + 1s)
+	require.Equal(t, 200.0, tps, "Third step should return startTps + incrementTps*2")
+
+	// Third step recovery phase
+	tps = rampCurve.GetTPS(14 * time.Second) // 10s + 3s load + 1s into recovery
+	require.Equal(t, 1.0, tps, "Third step recovery should return 1.0 TPS")
+}
+
+func TestRampCurveStep_Properties(t *testing.T) {
+	startTps := 75.0
+	incrementTps := 25.0
+	rampCurve := NewRampCurveStep(startTps, incrementTps, 2*time.Second, 1*time.Second)
+
+	require.Equal(t, startTps, rampCurve.GetStartTps(), "GetStartTps should return startTps")
+	require.Equal(t, incrementTps, rampCurve.GetIncrementTps(), "GetIncrementTps should return incrementTps")
 }

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -176,7 +176,7 @@ func (w *Worker) processTransactions(ctx context.Context, client *http.Client) e
 		// Apply rate limiting before getting the next transaction
 		if w.limiter != nil {
 			if !w.limiter.Allow() {
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(1 * time.Millisecond)
 				continue
 			}
 		}

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -180,8 +180,9 @@ func (w *Worker) processTransactions(ctx context.Context, client *http.Client) e
 
 		// Apply rate limiting before sending the transaction
 		if w.limiter != nil {
-			if err := w.limiter.Wait(ctx); err != nil {
-				return err
+			if allow := w.limiter.Allow(); !allow {
+				time.Sleep(1 * time.Millisecond)
+				continue
 			}
 		}
 

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -173,16 +173,17 @@ func (w *Worker) waitForReceipt(ctx context.Context, eth *ethclient.Client, tx *
 // processTransactions is the main worker loop that processes transactions
 func (w *Worker) processTransactions(ctx context.Context, client *http.Client) error {
 	for ctx.Err() == nil {
+		// Apply rate limiting before getting the next transaction
+		if w.limiter != nil {
+			if !w.limiter.Allow() {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+		}
+
 		tx, err := utils.Recv(ctx, w.txChan)
 		if err != nil {
 			return err
-		}
-
-		// Apply rate limiting before sending the transaction
-		if w.limiter != nil {
-			if err := w.limiter.Wait(ctx); err != nil {
-				return err
-			}
 		}
 
 		startTime := time.Now()

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -176,7 +176,6 @@ func (w *Worker) processTransactions(ctx context.Context, client *http.Client) e
 		// Apply rate limiting before getting the next transaction
 		if w.limiter != nil {
 			if !w.limiter.Allow() {
-				time.Sleep(1 * time.Millisecond)
 				continue
 			}
 		}

--- a/sender/worker.go
+++ b/sender/worker.go
@@ -180,9 +180,8 @@ func (w *Worker) processTransactions(ctx context.Context, client *http.Client) e
 
 		// Apply rate limiting before sending the transaction
 		if w.limiter != nil {
-			if allow := w.limiter.Allow(); !allow {
-				time.Sleep(1 * time.Millisecond)
-				continue
+			if err := w.limiter.Wait(ctx); err != nil {
+				return err
 			}
 		}
 

--- a/stats/block_collector.go
+++ b/stats/block_collector.go
@@ -205,6 +205,18 @@ func (bc *BlockCollector) GetWindowBlockStats() BlockStats {
 	panic("unreachable")
 }
 
+func (bc *BlockCollector) GetWindowBlockTimePercentile(percentile int) time.Duration {
+	for bc := range bc.stats.Lock() {
+		sortedTimes := make([]time.Duration, len(bc.windowBlockTimes))
+		copy(sortedTimes, bc.windowBlockTimes)
+		sort.Slice(sortedTimes, func(i, j int) bool {
+			return sortedTimes[i] < sortedTimes[j]
+		})
+		return calculatePercentile(sortedTimes, percentile)
+	}
+	panic("unreachable")
+}
+
 // ResetWindowStats resets the window-based statistics for the next reporting period
 func (bc *BlockCollector) ResetWindowStats() {
 	for bc := range bc.stats.Lock() {

--- a/stats/block_collector.go
+++ b/stats/block_collector.go
@@ -241,7 +241,7 @@ type BlockStats struct {
 }
 
 // FormatBlockStats returns a formatted string representation of block statistics
-func (bs *BlockStats) FormatBlockStats() string {
+func (bs BlockStats) FormatBlockStats() string {
 	if bs.SampleCount == 0 {
 		return "block stats: no data available"
 	}

--- a/stats/block_collector.go
+++ b/stats/block_collector.go
@@ -35,6 +35,13 @@ type BlockCollector struct {
 	stats      utils.Mutex[*blockCollectorStats]
 }
 
+type BlockStatsProvider interface {
+	GetBlockStats() BlockStats
+	GetWindowBlockStats() BlockStats
+	GetWindowBlockTimePercentile(percentile int) time.Duration
+	ResetWindowStats()
+}
+
 // NewBlockCollector creates a new block data collector
 func NewBlockCollector(seiChainID string) *BlockCollector {
 	return &BlockCollector{

--- a/stats/mock_block_collector.go
+++ b/stats/mock_block_collector.go
@@ -1,11 +1,13 @@
 package stats
 
 import (
+	"sync"
 	"time"
 )
 
 // MockBlockStats is a test implementation of BlockStatsProvider
 type MockBlockStats struct {
+	mu sync.RWMutex // mutex to prevent data races
 	// Preset return values for methods
 	blockStats       BlockStats
 	windowBlockStats BlockStats
@@ -24,44 +26,49 @@ func NewMockBlockStats() *MockBlockStats {
 
 // SetBlockStats sets the return value for GetBlockStats()
 func (m *MockBlockStats) SetBlockStats(stats BlockStats) *MockBlockStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.blockStats = stats
 	return m
 }
 
 // SetWindowBlockStats sets the return value for GetWindowBlockStats()
 func (m *MockBlockStats) SetWindowBlockStats(stats BlockStats) *MockBlockStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.windowBlockStats = stats
 	return m
 }
 
-// SetNextPercentile sets the return value for the next call to GetWindowBlockTimePercentile with the given percentile
-func (m *MockBlockStats) SetNextPercentile(percentile int, duration time.Duration) *MockBlockStats {
+// SetPercentile sets the return value for the next call to GetWindowBlockTimePercentile with the given percentile
+func (m *MockBlockStats) SetPercentile(percentile int, duration time.Duration) *MockBlockStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.percentileValues[percentile] = duration
 	return m
-}
-
-// SetPercentile is an alias for SetNextPercentile for more natural usage
-func (m *MockBlockStats) SetPercentile(percentile int, duration time.Duration) *MockBlockStats {
-	return m.SetNextPercentile(percentile, duration)
 }
 
 // Interface implementation methods
 
 // GetBlockStats returns the preset block stats
 func (m *MockBlockStats) GetBlockStats() BlockStats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.blockStats
 }
 
 // GetWindowBlockStats returns the preset window block stats
 func (m *MockBlockStats) GetWindowBlockStats() BlockStats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.windowBlockStats
 }
 
 // GetWindowBlockTimePercentile returns the preset value for the given percentile
 func (m *MockBlockStats) GetWindowBlockTimePercentile(percentile int) time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if duration, exists := m.percentileValues[percentile]; exists {
-		// Remove the value after returning it to simulate "next call" behavior
-		delete(m.percentileValues, percentile)
 		return duration
 	}
 	return 0
@@ -69,6 +76,8 @@ func (m *MockBlockStats) GetWindowBlockTimePercentile(percentile int) time.Durat
 
 // ResetWindowStats tracks the number of times it's called
 func (m *MockBlockStats) ResetWindowStats() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.resetCallCount++
 }
 
@@ -76,11 +85,15 @@ func (m *MockBlockStats) ResetWindowStats() {
 
 // GetResetCallCount returns how many times ResetWindowStats was called
 func (m *MockBlockStats) GetResetCallCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.resetCallCount
 }
 
 // HasPendingPercentile checks if there's a pending value for the given percentile
 func (m *MockBlockStats) HasPendingPercentile(percentile int) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	_, exists := m.percentileValues[percentile]
 	return exists
 }

--- a/stats/mock_block_collector.go
+++ b/stats/mock_block_collector.go
@@ -1,0 +1,86 @@
+package stats
+
+import (
+	"time"
+)
+
+// MockBlockStats is a test implementation of BlockStatsProvider
+type MockBlockStats struct {
+	// Preset return values for methods
+	blockStats       BlockStats
+	windowBlockStats BlockStats
+	percentileValues map[int]time.Duration
+	resetCallCount   int
+}
+
+// NewMockBlockStats creates a new MockBlockStats instance
+func NewMockBlockStats() *MockBlockStats {
+	return &MockBlockStats{
+		percentileValues: make(map[int]time.Duration),
+	}
+}
+
+// Setter methods for configuring mock return values
+
+// SetBlockStats sets the return value for GetBlockStats()
+func (m *MockBlockStats) SetBlockStats(stats BlockStats) *MockBlockStats {
+	m.blockStats = stats
+	return m
+}
+
+// SetWindowBlockStats sets the return value for GetWindowBlockStats()
+func (m *MockBlockStats) SetWindowBlockStats(stats BlockStats) *MockBlockStats {
+	m.windowBlockStats = stats
+	return m
+}
+
+// SetNextPercentile sets the return value for the next call to GetWindowBlockTimePercentile with the given percentile
+func (m *MockBlockStats) SetNextPercentile(percentile int, duration time.Duration) *MockBlockStats {
+	m.percentileValues[percentile] = duration
+	return m
+}
+
+// SetPercentile is an alias for SetNextPercentile for more natural usage
+func (m *MockBlockStats) SetPercentile(percentile int, duration time.Duration) *MockBlockStats {
+	return m.SetNextPercentile(percentile, duration)
+}
+
+// Interface implementation methods
+
+// GetBlockStats returns the preset block stats
+func (m *MockBlockStats) GetBlockStats() BlockStats {
+	return m.blockStats
+}
+
+// GetWindowBlockStats returns the preset window block stats
+func (m *MockBlockStats) GetWindowBlockStats() BlockStats {
+	return m.windowBlockStats
+}
+
+// GetWindowBlockTimePercentile returns the preset value for the given percentile
+func (m *MockBlockStats) GetWindowBlockTimePercentile(percentile int) time.Duration {
+	if duration, exists := m.percentileValues[percentile]; exists {
+		// Remove the value after returning it to simulate "next call" behavior
+		delete(m.percentileValues, percentile)
+		return duration
+	}
+	return 0
+}
+
+// ResetWindowStats tracks the number of times it's called
+func (m *MockBlockStats) ResetWindowStats() {
+	m.resetCallCount++
+}
+
+// Test helper methods
+
+// GetResetCallCount returns how many times ResetWindowStats was called
+func (m *MockBlockStats) GetResetCallCount() int {
+	return m.resetCallCount
+}
+
+// HasPendingPercentile checks if there's a pending value for the given percentile
+func (m *MockBlockStats) HasPendingPercentile(percentile int) bool {
+	_, exists := m.percentileValues[percentile]
+	return exists
+}

--- a/stats/mock_block_collector_test.go
+++ b/stats/mock_block_collector_test.go
@@ -3,22 +3,16 @@ package stats
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMockBlockStats(t *testing.T) {
 	mock := NewMockBlockStats()
 
-	if mock == nil {
-		t.Fatal("NewMockBlockStats should not return nil")
-	}
-
-	if mock.percentileValues == nil {
-		t.Error("percentileValues map should be initialized")
-	}
-
-	if mock.resetCallCount != 0 {
-		t.Error("resetCallCount should start at 0")
-	}
+	require.NotNil(t, mock, "NewMockBlockStats should not return nil")
+	require.NotNil(t, mock.percentileValues, "percentileValues map should be initialized")
+	require.Equal(t, 0, mock.resetCallCount, "resetCallCount should start at 0")
 }
 
 func TestMockBlockStats_SetBlockStats(t *testing.T) {
@@ -36,15 +30,11 @@ func TestMockBlockStats_SetBlockStats(t *testing.T) {
 
 	// Test fluent API
 	result := mock.SetBlockStats(expectedStats)
-	if result != mock {
-		t.Error("SetBlockStats should return the same mock instance for chaining")
-	}
+	require.Equal(t, mock, result, "SetBlockStats should return the same mock instance for chaining")
 
 	// Test that the stats are stored
 	actualStats := mock.GetBlockStats()
-	if actualStats != expectedStats {
-		t.Errorf("GetBlockStats() = %+v, want %+v", actualStats, expectedStats)
-	}
+	require.Equal(t, expectedStats, actualStats, "GetBlockStats() should return the expected stats")
 }
 
 func TestMockBlockStats_SetWindowBlockStats(t *testing.T) {
@@ -57,15 +47,11 @@ func TestMockBlockStats_SetWindowBlockStats(t *testing.T) {
 
 	// Test fluent API
 	result := mock.SetWindowBlockStats(expectedStats)
-	if result != mock {
-		t.Error("SetWindowBlockStats should return the same mock instance for chaining")
-	}
+	require.Equal(t, mock, result, "SetWindowBlockStats should return the same mock instance for chaining")
 
 	// Test that the stats are stored
 	actualStats := mock.GetWindowBlockStats()
-	if actualStats != expectedStats {
-		t.Errorf("GetWindowBlockStats() = %+v, want %+v", actualStats, expectedStats)
-	}
+	require.Equal(t, expectedStats, actualStats, "GetWindowBlockStats() should return the expected stats")
 }
 
 func TestMockBlockStats_PercentileMethods(t *testing.T) {
@@ -74,79 +60,51 @@ func TestMockBlockStats_PercentileMethods(t *testing.T) {
 	// Test SetNextPercentile
 	duration90 := 12 * time.Millisecond
 	result := mock.SetPercentile(90, duration90)
-	if result != mock {
-		t.Error("SetNextPercentile should return the same mock instance for chaining")
-	}
+	require.Equal(t, mock, result, "SetNextPercentile should return the same mock instance for chaining")
 
 	// Test SetPercentile (alias)
 	duration95 := 20 * time.Millisecond
 	result = mock.SetPercentile(95, duration95)
-	if result != mock {
-		t.Error("SetPercentile should return the same mock instance for chaining")
-	}
+	require.Equal(t, mock, result, "SetPercentile should return the same mock instance for chaining")
 
 	// Test HasPendingPercentile
-	if !mock.HasPendingPercentile(90) {
-		t.Error("HasPendingPercentile(90) should return true after setting")
-	}
-	if !mock.HasPendingPercentile(95) {
-		t.Error("HasPendingPercentile(95) should return true after setting")
-	}
-	if mock.HasPendingPercentile(99) {
-		t.Error("HasPendingPercentile(99) should return false when not set")
-	}
+	require.True(t, mock.HasPendingPercentile(90), "HasPendingPercentile(90) should return true after setting")
+	require.True(t, mock.HasPendingPercentile(95), "HasPendingPercentile(95) should return true after setting")
+	require.False(t, mock.HasPendingPercentile(99), "HasPendingPercentile(99) should return false when not set")
 
 	// Test GetWindowBlockTimePercentile returns correct values
 	actual90 := mock.GetWindowBlockTimePercentile(90)
-	if actual90 != duration90 {
-		t.Errorf("GetWindowBlockTimePercentile(90) = %v, want %v", actual90, duration90)
-	}
+	require.Equal(t, duration90, actual90, "GetWindowBlockTimePercentile(90) should return the expected value")
 
 	actual95 := mock.GetWindowBlockTimePercentile(95)
-	if actual95 != duration95 {
-		t.Errorf("GetWindowBlockTimePercentile(95) = %v, want %v", actual95, duration95)
-	}
+	require.Equal(t, duration95, actual95, "GetWindowBlockTimePercentile(95) should return the expected value")
 
 	// Test that values persist after being read (no longer cleared)
-	if !mock.HasPendingPercentile(90) {
-		t.Error("HasPendingPercentile(90) should still return true after reading value")
-	}
-	if !mock.HasPendingPercentile(95) {
-		t.Error("HasPendingPercentile(95) should still return true after reading value")
-	}
+	require.True(t, mock.HasPendingPercentile(90), "HasPendingPercentile(90) should still return true after reading value")
+	require.True(t, mock.HasPendingPercentile(95), "HasPendingPercentile(95) should still return true after reading value")
 
 	// Second call should return the same value (not cleared)
 	second90 := mock.GetWindowBlockTimePercentile(90)
-	if second90 != duration90 {
-		t.Errorf("Second call to GetWindowBlockTimePercentile(90) = %v, want %v", second90, duration90)
-	}
+	require.Equal(t, duration90, second90, "Second call to GetWindowBlockTimePercentile(90) should return the same value")
 
 	// Test unknown percentile returns 0
 	unknown := mock.GetWindowBlockTimePercentile(99)
-	if unknown != 0 {
-		t.Errorf("GetWindowBlockTimePercentile(99) = %v, want 0 for unknown percentile", unknown)
-	}
+	require.Equal(t, time.Duration(0), unknown, "GetWindowBlockTimePercentile(99) should return 0 for unknown percentile")
 }
 
 func TestMockBlockStats_ResetWindowStats(t *testing.T) {
 	mock := NewMockBlockStats()
 
 	// Initial count should be 0
-	if mock.GetResetCallCount() != 0 {
-		t.Errorf("Initial GetResetCallCount() = %d, want 0", mock.GetResetCallCount())
-	}
+	require.Equal(t, 0, mock.GetResetCallCount(), "Initial GetResetCallCount() should be 0")
 
 	// Call ResetWindowStats multiple times
 	mock.ResetWindowStats()
-	if mock.GetResetCallCount() != 1 {
-		t.Errorf("After 1 call, GetResetCallCount() = %d, want 1", mock.GetResetCallCount())
-	}
+	require.Equal(t, 1, mock.GetResetCallCount(), "After 1 call, GetResetCallCount() should be 1")
 
 	mock.ResetWindowStats()
 	mock.ResetWindowStats()
-	if mock.GetResetCallCount() != 3 {
-		t.Errorf("After 3 calls, GetResetCallCount() = %d, want 3", mock.GetResetCallCount())
-	}
+	require.Equal(t, 3, mock.GetResetCallCount(), "After 3 calls, GetResetCallCount() should be 3")
 }
 
 func TestMockBlockStats_FluentChaining(t *testing.T) {
@@ -162,23 +120,13 @@ func TestMockBlockStats_FluentChaining(t *testing.T) {
 		SetPercentile(50, 5*time.Millisecond).
 		SetPercentile(90, 15*time.Millisecond)
 
-	if result != mock {
-		t.Error("Fluent chaining should return the same mock instance")
-	}
+	require.Equal(t, mock, result, "Fluent chaining should return the same mock instance")
 
 	// Verify all values were set correctly
-	if mock.GetBlockStats() != blockStats {
-		t.Error("Block stats not set correctly through chaining")
-	}
-	if mock.GetWindowBlockStats() != windowStats {
-		t.Error("Window block stats not set correctly through chaining")
-	}
-	if !mock.HasPendingPercentile(50) {
-		t.Error("Percentile 50 not set correctly through chaining")
-	}
-	if !mock.HasPendingPercentile(90) {
-		t.Error("Percentile 90 not set correctly through chaining")
-	}
+	require.Equal(t, blockStats, mock.GetBlockStats(), "Block stats not set correctly through chaining")
+	require.Equal(t, windowStats, mock.GetWindowBlockStats(), "Window block stats not set correctly through chaining")
+	require.True(t, mock.HasPendingPercentile(50), "Percentile 50 not set correctly through chaining")
+	require.True(t, mock.HasPendingPercentile(90), "Percentile 90 not set correctly through chaining")
 }
 
 func TestMockBlockStats_BlockStatsProviderInterface(t *testing.T) {
@@ -198,18 +146,12 @@ func TestMockBlockStats_DefaultValues(t *testing.T) {
 	// Test default empty BlockStats
 	blockStats := mock.GetBlockStats()
 	expectedEmpty := BlockStats{}
-	if blockStats != expectedEmpty {
-		t.Errorf("Default GetBlockStats() = %+v, want empty BlockStats", blockStats)
-	}
+	require.Equal(t, expectedEmpty, blockStats, "Default GetBlockStats() should return empty BlockStats")
 
 	windowStats := mock.GetWindowBlockStats()
-	if windowStats != expectedEmpty {
-		t.Errorf("Default GetWindowBlockStats() = %+v, want empty BlockStats", windowStats)
-	}
+	require.Equal(t, expectedEmpty, windowStats, "Default GetWindowBlockStats() should return empty BlockStats")
 
 	// Test default percentile value
 	percentile := mock.GetWindowBlockTimePercentile(50)
-	if percentile != 0 {
-		t.Errorf("Default GetWindowBlockTimePercentile(50) = %v, want 0", percentile)
-	}
+	require.Equal(t, time.Duration(0), percentile, "Default GetWindowBlockTimePercentile(50) should return 0")
 }

--- a/stats/mock_block_collector_test.go
+++ b/stats/mock_block_collector_test.go
@@ -73,7 +73,7 @@ func TestMockBlockStats_PercentileMethods(t *testing.T) {
 
 	// Test SetNextPercentile
 	duration90 := 12 * time.Millisecond
-	result := mock.SetNextPercentile(90, duration90)
+	result := mock.SetPercentile(90, duration90)
 	if result != mock {
 		t.Error("SetNextPercentile should return the same mock instance for chaining")
 	}
@@ -107,18 +107,18 @@ func TestMockBlockStats_PercentileMethods(t *testing.T) {
 		t.Errorf("GetWindowBlockTimePercentile(95) = %v, want %v", actual95, duration95)
 	}
 
-	// Test "next call" behavior - values should be consumed
-	if mock.HasPendingPercentile(90) {
-		t.Error("HasPendingPercentile(90) should return false after consumption")
+	// Test that values persist after being read (no longer cleared)
+	if !mock.HasPendingPercentile(90) {
+		t.Error("HasPendingPercentile(90) should still return true after reading value")
 	}
-	if mock.HasPendingPercentile(95) {
-		t.Error("HasPendingPercentile(95) should return false after consumption")
+	if !mock.HasPendingPercentile(95) {
+		t.Error("HasPendingPercentile(95) should still return true after reading value")
 	}
 
-	// Second call should return 0 (default)
+	// Second call should return the same value (not cleared)
 	second90 := mock.GetWindowBlockTimePercentile(90)
-	if second90 != 0 {
-		t.Errorf("Second call to GetWindowBlockTimePercentile(90) = %v, want 0", second90)
+	if second90 != duration90 {
+		t.Errorf("Second call to GetWindowBlockTimePercentile(90) = %v, want %v", second90, duration90)
 	}
 
 	// Test unknown percentile returns 0
@@ -160,7 +160,7 @@ func TestMockBlockStats_FluentChaining(t *testing.T) {
 		SetBlockStats(blockStats).
 		SetWindowBlockStats(windowStats).
 		SetPercentile(50, 5*time.Millisecond).
-		SetNextPercentile(90, 15*time.Millisecond)
+		SetPercentile(90, 15*time.Millisecond)
 
 	if result != mock {
 		t.Error("Fluent chaining should return the same mock instance")

--- a/stats/mock_block_collector_test.go
+++ b/stats/mock_block_collector_test.go
@@ -1,0 +1,215 @@
+package stats
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewMockBlockStats(t *testing.T) {
+	mock := NewMockBlockStats()
+
+	if mock == nil {
+		t.Fatal("NewMockBlockStats should not return nil")
+	}
+
+	if mock.percentileValues == nil {
+		t.Error("percentileValues map should be initialized")
+	}
+
+	if mock.resetCallCount != 0 {
+		t.Error("resetCallCount should start at 0")
+	}
+}
+
+func TestMockBlockStats_SetBlockStats(t *testing.T) {
+	mock := NewMockBlockStats()
+	expectedStats := BlockStats{
+		MaxBlockNumber: 1000,
+		P50BlockTime:   5 * time.Second,
+		P99BlockTime:   10 * time.Second,
+		MaxBlockTime:   15 * time.Second,
+		P50GasUsed:     21000,
+		P99GasUsed:     50000,
+		MaxGasUsed:     100000,
+		SampleCount:    100,
+	}
+
+	// Test fluent API
+	result := mock.SetBlockStats(expectedStats)
+	if result != mock {
+		t.Error("SetBlockStats should return the same mock instance for chaining")
+	}
+
+	// Test that the stats are stored
+	actualStats := mock.GetBlockStats()
+	if actualStats != expectedStats {
+		t.Errorf("GetBlockStats() = %+v, want %+v", actualStats, expectedStats)
+	}
+}
+
+func TestMockBlockStats_SetWindowBlockStats(t *testing.T) {
+	mock := NewMockBlockStats()
+	expectedStats := BlockStats{
+		MaxBlockNumber: 500,
+		P50BlockTime:   3 * time.Second,
+		SampleCount:    50,
+	}
+
+	// Test fluent API
+	result := mock.SetWindowBlockStats(expectedStats)
+	if result != mock {
+		t.Error("SetWindowBlockStats should return the same mock instance for chaining")
+	}
+
+	// Test that the stats are stored
+	actualStats := mock.GetWindowBlockStats()
+	if actualStats != expectedStats {
+		t.Errorf("GetWindowBlockStats() = %+v, want %+v", actualStats, expectedStats)
+	}
+}
+
+func TestMockBlockStats_PercentileMethods(t *testing.T) {
+	mock := NewMockBlockStats()
+
+	// Test SetNextPercentile
+	duration90 := 12 * time.Millisecond
+	result := mock.SetNextPercentile(90, duration90)
+	if result != mock {
+		t.Error("SetNextPercentile should return the same mock instance for chaining")
+	}
+
+	// Test SetPercentile (alias)
+	duration95 := 20 * time.Millisecond
+	result = mock.SetPercentile(95, duration95)
+	if result != mock {
+		t.Error("SetPercentile should return the same mock instance for chaining")
+	}
+
+	// Test HasPendingPercentile
+	if !mock.HasPendingPercentile(90) {
+		t.Error("HasPendingPercentile(90) should return true after setting")
+	}
+	if !mock.HasPendingPercentile(95) {
+		t.Error("HasPendingPercentile(95) should return true after setting")
+	}
+	if mock.HasPendingPercentile(99) {
+		t.Error("HasPendingPercentile(99) should return false when not set")
+	}
+
+	// Test GetWindowBlockTimePercentile returns correct values
+	actual90 := mock.GetWindowBlockTimePercentile(90)
+	if actual90 != duration90 {
+		t.Errorf("GetWindowBlockTimePercentile(90) = %v, want %v", actual90, duration90)
+	}
+
+	actual95 := mock.GetWindowBlockTimePercentile(95)
+	if actual95 != duration95 {
+		t.Errorf("GetWindowBlockTimePercentile(95) = %v, want %v", actual95, duration95)
+	}
+
+	// Test "next call" behavior - values should be consumed
+	if mock.HasPendingPercentile(90) {
+		t.Error("HasPendingPercentile(90) should return false after consumption")
+	}
+	if mock.HasPendingPercentile(95) {
+		t.Error("HasPendingPercentile(95) should return false after consumption")
+	}
+
+	// Second call should return 0 (default)
+	second90 := mock.GetWindowBlockTimePercentile(90)
+	if second90 != 0 {
+		t.Errorf("Second call to GetWindowBlockTimePercentile(90) = %v, want 0", second90)
+	}
+
+	// Test unknown percentile returns 0
+	unknown := mock.GetWindowBlockTimePercentile(99)
+	if unknown != 0 {
+		t.Errorf("GetWindowBlockTimePercentile(99) = %v, want 0 for unknown percentile", unknown)
+	}
+}
+
+func TestMockBlockStats_ResetWindowStats(t *testing.T) {
+	mock := NewMockBlockStats()
+
+	// Initial count should be 0
+	if mock.GetResetCallCount() != 0 {
+		t.Errorf("Initial GetResetCallCount() = %d, want 0", mock.GetResetCallCount())
+	}
+
+	// Call ResetWindowStats multiple times
+	mock.ResetWindowStats()
+	if mock.GetResetCallCount() != 1 {
+		t.Errorf("After 1 call, GetResetCallCount() = %d, want 1", mock.GetResetCallCount())
+	}
+
+	mock.ResetWindowStats()
+	mock.ResetWindowStats()
+	if mock.GetResetCallCount() != 3 {
+		t.Errorf("After 3 calls, GetResetCallCount() = %d, want 3", mock.GetResetCallCount())
+	}
+}
+
+func TestMockBlockStats_FluentChaining(t *testing.T) {
+	mock := NewMockBlockStats()
+
+	blockStats := BlockStats{MaxBlockNumber: 1000}
+	windowStats := BlockStats{MaxBlockNumber: 500}
+
+	// Test chaining multiple setter calls
+	result := mock.
+		SetBlockStats(blockStats).
+		SetWindowBlockStats(windowStats).
+		SetPercentile(50, 5*time.Millisecond).
+		SetNextPercentile(90, 15*time.Millisecond)
+
+	if result != mock {
+		t.Error("Fluent chaining should return the same mock instance")
+	}
+
+	// Verify all values were set correctly
+	if mock.GetBlockStats() != blockStats {
+		t.Error("Block stats not set correctly through chaining")
+	}
+	if mock.GetWindowBlockStats() != windowStats {
+		t.Error("Window block stats not set correctly through chaining")
+	}
+	if !mock.HasPendingPercentile(50) {
+		t.Error("Percentile 50 not set correctly through chaining")
+	}
+	if !mock.HasPendingPercentile(90) {
+		t.Error("Percentile 90 not set correctly through chaining")
+	}
+}
+
+func TestMockBlockStats_BlockStatsProviderInterface(t *testing.T) {
+	// Test that MockBlockStats implements BlockStatsProvider interface
+	var provider BlockStatsProvider = NewMockBlockStats()
+
+	// This should compile without errors if interface is properly implemented
+	_ = provider.GetBlockStats()
+	_ = provider.GetWindowBlockStats()
+	_ = provider.GetWindowBlockTimePercentile(50)
+	provider.ResetWindowStats()
+}
+
+func TestMockBlockStats_DefaultValues(t *testing.T) {
+	mock := NewMockBlockStats()
+
+	// Test default empty BlockStats
+	blockStats := mock.GetBlockStats()
+	expectedEmpty := BlockStats{}
+	if blockStats != expectedEmpty {
+		t.Errorf("Default GetBlockStats() = %+v, want empty BlockStats", blockStats)
+	}
+
+	windowStats := mock.GetWindowBlockStats()
+	if windowStats != expectedEmpty {
+		t.Errorf("Default GetWindowBlockStats() = %+v, want empty BlockStats", windowStats)
+	}
+
+	// Test default percentile value
+	percentile := mock.GetWindowBlockTimePercentile(50)
+	if percentile != 0 {
+		t.Errorf("Default GetWindowBlockTimePercentile(50) = %v, want 0", percentile)
+	}
+}


### PR DESCRIPTION
This adds a ramping loadtest that can be used test progressive levels of load on a loadtest cluster to identify the point at which we experience failure to meet SLO (which is p90 block times of 1s in this case). This can be run with any scenario as specified, and we can configure later CI to run loadtests for varying scenarios to evaluate TPS under different load profiles.