### PR TITLE
[CON-92] Fix contract deployment and contract txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Edit `my-config.json`:
 ```json
 {
   "endpoints": ["http://localhost:8545"],
-  "chainId": 1329,
+  "chainId": 713714,
   "scenarios": [
     {"name": "EVMTransfer", "weight": 100}
   ],
@@ -94,7 +94,7 @@ Edit `my-config.json`:
 ```json
 {
   "endpoints": ["http://localhost:8545"],
-  "chainId": 1329,
+  "chainId": 713714,
   "scenarios": [...],
   "accounts": {...},
   "settings": {...}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -134,15 +134,13 @@ func (g *configBasedGenerator) deployAll() error {
 	// Deploy sequentially to ensure proper nonce management
 	for _, instance := range g.instances {
 		// Deploy the scenario
+		log.Printf("Deploying scenario %s", instance.Name)
 		address := instance.Scenario.Deploy(g.config, g.deployer)
 		instance.Deployed = true
 
 		if address.Cmp(common.Address{}) != 0 {
 			log.Printf("🚀 Deployed %s at address: %s\n", instance.Name, address.Hex())
 		}
-
-		// Increment deployer nonce for next deployment
-		g.deployer.GetAndIncrementNonce()
 	}
 
 	return nil

--- a/generator/prewarm.go
+++ b/generator/prewarm.go
@@ -79,7 +79,6 @@ func (pg *PrewarmGenerator) Generate() (*types.LoadTx, bool) {
 		Name:     "EVMTransfer",
 		Sender:   account,
 		Receiver: account.Address, // Send to self
-		Nonce:    account.GetAndIncrementNonce(),
 	}
 
 	// Generate the transaction using EVMTransfer scenario

--- a/generator/scenario.go
+++ b/generator/scenario.go
@@ -40,7 +40,6 @@ func (g *scenarioGenerator) Generate() (*types.LoadTx, bool) {
 		Name:     g.scenario.Name(),
 		Sender:   sender,
 		Receiver: receiver.Address,
-		Nonce:    sender.GetAndIncrementNonce(),
 	}), true
 }
 

--- a/generator/scenarios/EVMTransfer.go
+++ b/generator/scenarios/EVMTransfer.go
@@ -48,7 +48,7 @@ func (s *EVMTransferScenario) AttachScenario(config *config.LoadConfig, address 
 func (s *EVMTransferScenario) CreateTransaction(config *config.LoadConfig, scenario *types2.TxScenario) (*ethtypes.Transaction, error) {
 	// Create transaction with value transfer
 	tx := &ethtypes.DynamicFeeTx{
-		Nonce:     scenario.Nonce,
+		Nonce:     scenario.Sender.GetAndIncrementNonce(),
 		To:        &scenario.Receiver,
 		Value:     big.NewInt(time.Now().Unix()),
 		Gas:       21000,                   // Standard gas limit for ETH transfer

--- a/generator/scenarios/EVMTransferNoop.go
+++ b/generator/scenarios/EVMTransferNoop.go
@@ -47,7 +47,7 @@ func (s *EVMTransferNoopScenario) AttachScenario(config *config.LoadConfig, addr
 func (s *EVMTransferNoopScenario) CreateTransaction(config *config.LoadConfig, scenario *types2.TxScenario) (*ethtypes.Transaction, error) {
 	// Create transaction with value transfer
 	tx := &ethtypes.DynamicFeeTx{
-		Nonce:     scenario.Nonce,
+		Nonce:     scenario.Sender.GetAndIncrementNonce(),
 		To:        &scenario.Sender.Address,
 		Value:     big.NewInt(0),
 		Gas:       21000,                   // Standard gas limit for ETH transfer

--- a/generator/scenarios/base.go
+++ b/generator/scenarios/base.go
@@ -186,7 +186,7 @@ func (c *ContractScenarioBase[T]) DeployScenario(config *config.LoadConfig, depl
 	log.Printf("📤 Deployment transaction sent: %s", tx.Hash().Hex())
 
 	// Wait for the deployment transaction to be mined
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	receipt, err := bind.WaitMined(ctx, client, tx)
@@ -200,6 +200,7 @@ func (c *ContractScenarioBase[T]) DeployScenario(config *config.LoadConfig, depl
 	}
 
 	log.Printf("✅ Deployment successful at block %d (gas used: %d)", receipt.BlockNumber.Uint64(), receipt.GasUsed)
+	deployer.GetAndIncrementNonce()
 
 	// Bind contract instance using the provided bind function
 	bindFunc := c.deployer.GetBindFunc()

--- a/generator/scenarios/base.go
+++ b/generator/scenarios/base.go
@@ -200,7 +200,6 @@ func (c *ContractScenarioBase[T]) DeployScenario(config *config.LoadConfig, depl
 	}
 
 	log.Printf("✅ Deployment successful at block %d (gas used: %d)", receipt.BlockNumber.Uint64(), receipt.GasUsed)
-	deployer.GetAndIncrementNonce()
 
 	// Bind contract instance using the provided bind function
 	bindFunc := c.deployer.GetBindFunc()

--- a/generator/utils/utils.go
+++ b/generator/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,7 +47,6 @@ func createTransactOpts(chainID *big.Int, account *loadtypes.Account, gasLimit u
 	// Set transaction parameters
 	auth.Nonce = big.NewInt(int64(account.Nonce))
 	auth.NoSend = noSend
-	auth.Value = big.NewInt(time.Now().Unix())
 
 	auth.GasLimit = gasLimit
 	auth.GasTipCap = big.NewInt(2000000000)  // 2 gwei tip (priority fee)

--- a/generator/utils/utils.go
+++ b/generator/utils/utils.go
@@ -45,7 +45,7 @@ func createTransactOpts(chainID *big.Int, account *loadtypes.Account, gasLimit u
 	}
 
 	// Set transaction parameters
-	auth.Nonce = big.NewInt(int64(account.Nonce))
+	auth.Nonce = big.NewInt(int64(account.GetAndIncrementNonce()))
 	auth.NoSend = noSend
 
 	auth.GasLimit = gasLimit
@@ -68,6 +68,5 @@ func CreateTransactionOpts(chainID *big.Int, scenario *loadtypes.TxScenario) *bi
 	if err != nil {
 		panic("Failed to create transaction options: " + err.Error())
 	}
-	opts.Nonce.SetUint64(scenario.Nonce)
 	return opts
 }

--- a/types/scenario.go
+++ b/types/scenario.go
@@ -49,7 +49,6 @@ func (tx *LoadTx) ShardID(n int) int {
 // TxScenario captures the scenario of this test transaction.
 type TxScenario struct {
 	Name     string
-	Nonce    uint64
 	Sender   *Account
 	Receiver common.Address
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -250,18 +250,18 @@ func TestCreateTxFromEthTx(t *testing.T) {
 	account, err := NewAccount()
 	require.NoError(t, err)
 
+	account.Nonce = 42
 	receiver := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	scenario := &TxScenario{
 		Name:     "TestScenario",
-		Nonce:    42,
 		Sender:   account,
 		Receiver: receiver,
 	}
 
 	// Create a test transaction using DynamicFeeTx (EIP-1559)
 	tx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   big.NewInt(1329), // Sei testnet chain ID
-		Nonce:     scenario.Nonce,
+		ChainID:   big.NewInt(713714), // Sei testnet chain ID
+		Nonce:     scenario.Sender.Nonce,
 		GasTipCap: big.NewInt(2000000000),  // 2 Gwei tip
 		GasFeeCap: big.NewInt(20000000000), // 20 Gwei max fee
 		Gas:       21000,                   // Gas limit
@@ -314,15 +314,15 @@ func TestLoadTxShardID(t *testing.T) {
 				account := accounts[i%len(accounts)]
 				scenario := &TxScenario{
 					Name:     "TestScenario",
-					Nonce:    uint64(i),
 					Sender:   account,
 					Receiver: common.Address{},
 				}
 
+				scenario.Sender.Nonce = uint64(i)
 				// Create a simple transaction
 				tx := types.NewTx(&types.DynamicFeeTx{
-					ChainID:   big.NewInt(1329), // Sei testnet chain ID
-					Nonce:     scenario.Nonce,
+					ChainID:   big.NewInt(713714), // Sei testnet chain ID
+					Nonce:     scenario.Sender.Nonce,
 					GasTipCap: big.NewInt(2000000000),  // 2 Gwei tip
 					GasFeeCap: big.NewInt(20000000000), // 20 Gwei max fee
 					Gas:       21000,                   // Gas limit
@@ -374,14 +374,13 @@ func TestLoadTxShardIDConsistency(t *testing.T) {
 
 	scenario := &TxScenario{
 		Name:     "TestScenario",
-		Nonce:    0,
 		Sender:   account,
 		Receiver: common.Address{},
 	}
 
 	tx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   big.NewInt(1329), // Sei testnet chain ID
-		Nonce:     scenario.Nonce,
+		ChainID:   big.NewInt(713714), // Sei testnet chain ID
+		Nonce:     scenario.Sender.Nonce,
 		GasTipCap: big.NewInt(2000000000),  // 2 Gwei tip
 		GasFeeCap: big.NewInt(20000000000), // 20 Gwei max fee
 		Gas:       21000,                   // Gas limit
@@ -408,16 +407,17 @@ func TestTxScenario(t *testing.T) {
 
 	receiver := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
 
+	account.Nonce = 123
+
 	scenario := &TxScenario{
 		Name:     "TestScenario",
-		Nonce:    123,
 		Sender:   account,
 		Receiver: receiver,
 	}
 
 	// Verify all fields are set correctly
 	assert.Equal(t, "TestScenario", scenario.Name)
-	assert.Equal(t, uint64(123), scenario.Nonce)
+	assert.Equal(t, uint64(123), scenario.Sender.Nonce)
 	assert.Equal(t, account, scenario.Sender)
 	assert.Equal(t, receiver, scenario.Receiver)
 }
@@ -477,14 +477,13 @@ func BenchmarkCreateTxFromEthTx(b *testing.B) {
 
 	scenario := &TxScenario{
 		Name:     "BenchmarkScenario",
-		Nonce:    0,
 		Sender:   account,
 		Receiver: common.Address{},
 	}
 
 	tx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   big.NewInt(1329), // Sei testnet chain ID
-		Nonce:     scenario.Nonce,
+		ChainID:   big.NewInt(713714), // Sei testnet chain ID
+		Nonce:     scenario.Sender.Nonce,
 		GasTipCap: big.NewInt(2000000000),  // 2 Gwei tip
 		GasFeeCap: big.NewInt(20000000000), // 20 Gwei max fee
 		Gas:       21000,                   // Gas limit


### PR DESCRIPTION
We don't use the deployer account for anything else outside of deployments, and it is randomly generated anyways, so we can instead use a new deployer for each contract to prevent nonce or account related issues causing timeouts on deployments.