### PR TITLE
Add EvmTransferFast scenario

### DIFF
--- a/generator/scenarios/EVMTransferFast.go
+++ b/generator/scenarios/EVMTransferFast.go
@@ -1,0 +1,90 @@
+package scenarios
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/sei-protocol/sei-load/config"
+	types2 "github.com/sei-protocol/sei-load/types"
+)
+
+const EVMTransferFast = "evmtransferfast"
+
+// EVMTransferFastScenario implements the TxGenerator interface for simple ETH transfers
+// that only involve values that are multiples of 10^12 and no tipping.
+type EVMTransferFastScenario struct {
+	*ScenarioBase
+}
+
+// NewEVMTransferScenario creates a new ETH transfer scenario
+func NewEVMTransferFastScenario(cfg config.Scenario) TxGenerator {
+	scenario := &EVMTransferFastScenario{}
+	scenario.ScenarioBase = NewScenarioBase(scenario, cfg)
+	return scenario
+}
+
+// Name returns the name of the scenario.
+func (s *EVMTransferFastScenario) Name() string {
+	return EVMTransfer
+}
+
+// DeployScenario implements ScenarioDeployer interface - no deployment needed for ETH transfers
+func (s *EVMTransferFastScenario) DeployScenario(config *config.LoadConfig, deployer *types2.Account) common.Address {
+	// No deployment needed for simple ETH transfers
+	// Return zero address to indicate no contract deployment
+	return common.Address{}
+}
+
+// AttachScenario implements ScenarioDeployer interface - no attachment needed for ETH transfers.
+func (s *EVMTransferFastScenario) AttachScenario(config *config.LoadConfig, address common.Address) common.Address {
+	// No attachment needed for simple ETH transfers
+	// Return zero address to indicate no contract deployment
+	return common.Address{}
+}
+
+// CreateTransaction EVMTransferFastScenario ScenarioDeployer interface - creates ETH transfer transaction
+func (s *EVMTransferFastScenario) CreateTransaction(config *config.LoadConfig, scenario *types2.TxScenario) (*ethtypes.Transaction, error) {
+	// Create transaction with value transfer
+	tx := &ethtypes.DynamicFeeTx{
+		Nonce:     scenario.Sender.GetAndIncrementNonce(),
+		To:        &scenario.Receiver,
+		Value:     big.NewInt(1_000_000_000_000),
+		Gas:       21000,                    // Standard gas limit for ETH transfer
+		GasTipCap: big.NewInt(0),            // 2 gwei
+		GasFeeCap: big.NewInt(200000000000), // 200 gwei
+		Data:      nil,                      // No data for simple transfer
+	}
+
+	if s.scenarioConfig.GasPicker != nil {
+		var err error
+		tx.Gas, err = s.scenarioConfig.GasPicker.GenerateGas()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if s.scenarioConfig.GasTipCapPicker != nil {
+		gasTipCap, err := s.scenarioConfig.GasTipCapPicker.GenerateGas()
+		if err != nil {
+			return nil, err
+		}
+		tx.GasTipCap = big.NewInt(int64(gasTipCap))
+	}
+	if s.scenarioConfig.GasFeeCapPicker != nil {
+		gasFeeCap, err := s.scenarioConfig.GasFeeCapPicker.GenerateGas()
+		if err != nil {
+			return nil, err
+		}
+		tx.GasFeeCap = big.NewInt(int64(gasFeeCap))
+	}
+
+	// Sign the transaction
+	signer := ethtypes.NewCancunSigner(config.GetChainID())
+	signedTx, err := ethtypes.SignTx(ethtypes.NewTx(tx), signer, scenario.Sender.PrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return signedTx, nil
+}

--- a/generator/scenarios/factory.go
+++ b/generator/scenarios/factory.go
@@ -13,6 +13,7 @@ type ScenarioFactory func(s config.Scenario) TxGenerator
 var scenarioFactories = map[string]ScenarioFactory{
 	// Manual entries for non-contract scenarios
 	EVMTransfer:     NewEVMTransferScenario,
+	EVMTransferFast: NewEVMTransferFastScenario,
 	EVMTransferNoop: NewEVMTransferNoopScenario,
 
 	// Auto-generated entries will be added below this line by make generate

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
-	github.com/ethereum/c-kzg-4844/v2 v2.1.1 // indirect
+	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/deepmap/oapi-codegen v1.6.0 h1:w/d1ntwh91XI0b/8ja7+u5SvA4IFfM0UNNLmiDR1gg0=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=
-github.com/ethereum/c-kzg-4844/v2 v2.1.1 h1:KhzBVjmURsfr1+S3k/VE35T02+AW2qU9t9gr4R6YpSo=
-github.com/ethereum/c-kzg-4844/v2 v2.1.1/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
+github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
+github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-ethereum v1.16.1 h1:7684NfKCb1+IChudzdKyZJ12l1Tq4ybPZOITiCDXqCk=
 github.com/ethereum/go-ethereum v1.16.1/go.mod h1:ngYIvmMAYdo4sGW9cGzLvSsPGhDOOzL0jK5S5iXpj0g=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=


### PR DESCRIPTION
Add a new scenarios that would result in fewer writes per transaction:
- transfer value is multiple of 10^12 so there will not be wei writes
- tip cap is set to 0 so there will not be fee payment to validator (if base fee is set to 0 on the chain being benchmarked)