### PR TITLE
fix(metrics): drop redundant _seconds suffix on run_duration metric name

### DIFF
--- a/stats/metrics.go
+++ b/stats/metrics.go
@@ -33,7 +33,7 @@ var (
 		metric.WithUnit("{transactions}/s")))
 
 	runDurationSeconds = must(meter.Float64Gauge(
-		"run_duration_seconds",
+		"run_duration",
 		metric.WithDescription("Wall-clock duration of this run (emitted once at run end)"),
 		metric.WithUnit("s")))
 


### PR DESCRIPTION
## Summary
- Metric was named \`run_duration_seconds\` *and* annotated with \`metric.WithUnit(\"s\")\`. The OTel Prometheus exporter appends \`_seconds\` to any metric with unit \`s\`, producing \`seiload_run_duration_seconds_seconds\` — a double-suffix that broke PromQL queries assuming the canonical name.
- Rename to \`run_duration\` so the exporter produces \`seiload_run_duration_seconds\`, matching the same convention used by \`block_time\` in this file (\`block_time\` + unit \`s\` → \`seiload_block_time_seconds\`).

## Why this matters
The harbor nightly alert \`NightlyRunFailed\` was first written against the double-suffix name (it had to be — that's what was actually exported), making it harder to discover and review. Standardizing to \`seiload_run_duration_seconds\` aligns with OTel semantic conventions and Prometheus norms.

## Coordination
A paired platform-repo PR will atomically:
1. Bump the pinned seiload image tag in \`.github/workflows/k8s_nightly.yml\` to the SHA built from this PR
2. Update the alert query in \`clusters/harbor/monitoring/alerts/protocol/alerts-nightly.yaml\` from \`seiload_run_duration_seconds_seconds\` → \`seiload_run_duration_seconds\`

Both must land in one PR or the alert will spuriously fire (or never fire, depending on which side ships first).

## Test plan
- [x] \`go build ./...\` clean
- [x] After merge: image publishes; verify in Prometheus that \`seiload_run_duration_seconds\` is emitted (single suffix) on the next nightly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)