### PR TITLE
feat: add --duration flag for self-terminated load runs

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func init() {
 	rootCmd.Flags().Uint64("target-gas", 10_000_000, "Target gas per block")
 	rootCmd.Flags().Int("num-blocks-to-write", 100, "Number of blocks to write")
 	rootCmd.Flags().Duration("post-summary-flush-delay", 25*time.Second, "In-process delay after run-summary metrics are recorded, allowing Prometheus to scrape them before exit")
-	rootCmd.Flags().Duration("duration", 0, "Run duration; the load test ctx is canceled after this elapses, the existing graceful-shutdown path runs, and the process exits 0. 0 means run until SIGTERM/SIGINT.")
+	rootCmd.Flags().Duration("duration", 0, "Run duration (0 = until SIGTERM/SIGINT)")
 
 	// Initialize Viper with proper error handling
 	if err := config.InitializeViper(rootCmd); err != nil {

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func init() {
 	rootCmd.Flags().Uint64("target-gas", 10_000_000, "Target gas per block")
 	rootCmd.Flags().Int("num-blocks-to-write", 100, "Number of blocks to write")
 	rootCmd.Flags().Duration("post-summary-flush-delay", 25*time.Second, "In-process delay after run-summary metrics are recorded, allowing Prometheus to scrape them before exit")
+	rootCmd.Flags().Duration("duration", 0, "Run duration; the load test ctx is canceled after this elapses, the existing graceful-shutdown path runs, and the process exits 0. 0 means run until SIGTERM/SIGINT.")
 
 	// Initialize Viper with proper error handling
 	if err := config.InitializeViper(rootCmd); err != nil {
@@ -188,6 +189,13 @@ func runLoadTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 			log.Printf("metrics server shutdown: %v", err)
 		}
 	}()
+
+	if duration, _ := cmd.Flags().GetDuration("duration"); duration > 0 {
+		log.Printf("⏰ Run duration: %s", duration)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, duration)
+		defer cancel()
+	}
 
 	ctx, runSpan := otel.Tracer("github.com/sei-protocol/sei-load").Start(ctx, "seiload.run")
 	defer runSpan.End()


### PR DESCRIPTION
## Summary

Add `--duration` flag so seiload self-terminates cleanly inside K8s Job `activeDeadlineSeconds`, producing pod exit 0 → Job condition `Complete` instead of K8s-mandated `Failed/DeadlineExceeded`.

## Why this exists

Followup to #30. The exit-code fix in #30 is correct in isolation (graceful SIGTERM → exit 0), but on Kubernetes Jobs with **Job-level `activeDeadlineSeconds`**, the K8s Job controller sets `condition=Failed, reason=DeadlineExceeded` *regardless of the container's exit code*:

> Once a Job reaches activeDeadlineSeconds, all of its running Pods are terminated and the Job status will become type: Failed with reason: DeadlineExceeded.
> — [Kubernetes Job docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup)

A run on harbor's `nightly` namespace today (workflow [25189102396](https://github.com/sei-protocol/platform/actions/runs/25189102396)) confirmed this: seiload's pod was SIGTERMed at the deadline and likely exited 0 (post-#30), but the Job condition was set:

```
"reason": "DeadlineExceeded",
"message": "Job was active longer than specified deadline"
```

This means `kube_job_failed=1` and `KubeJobFailed` keeps firing — the original symptom that motivated this whole investigation. The actual fix has to make seiload self-terminate *before* K8s decides "DeadlineExceeded."

## What changes

```go
rootCmd.Flags().Duration("duration", 0, "Run duration; the load test ctx is canceled after this elapses, the existing graceful-shutdown path runs, and the process exits 0. 0 means run until SIGTERM/SIGINT.")
```

```go
if duration, _ := cmd.Flags().GetDuration("duration"); duration > 0 {
    log.Printf("⏰ Run duration: %s", duration)
    var cancel context.CancelFunc
    ctx, cancel = context.WithTimeout(ctx, duration)
    defer cancel()
}
```

When `--duration` is set:
1. The load-test context is wrapped with `WithTimeout`.
2. After `duration` elapses, ctx is canceled with `context.DeadlineExceeded`.
3. Background tasks (dispatcher, logger, block_collector) unwind via `ctx.Done()`.
4. `service.Run` returns the wrapped DeadlineExceeded error.
5. Final stats emit, `EmitRunSummary` runs, post-summary flush sleeps for 45s.
6. Existing boundary check from #30 (`errors.Is(err, context.DeadlineExceeded)`) clears the error.
7. Process exits 0.

The existing post-summary flush delay still runs by design — it sits *after* `service.Run` returns, in the cleanup pipeline.

## What doesn't change

- Default is `0` (unlimited) so existing callers without the flag are unaffected.
- SIGTERM/SIGINT handling in `main.go:347-352` is untouched and still works.
- Exit-code semantics from #30 (Canceled OR DeadlineExceeded → exit 0) already cover both internal-timeout and external-SIGTERM paths.

## Test plan

- [x] `GOWORK=off go build .` passes
- [x] `GOWORK=off go vet ./...` clean
- [x] Companion platform PR will pass `--duration=${DURATION_MINUTES}m` to seiload args; tomorrow's nightly will verify Job condition flips to `Complete`

## Companion change

Will follow with a small PR on `sei-protocol/platform` that:
1. Bumps the seiload image to the new SHA after this merges.
2. Adds `--duration=${DURATION_MINUTES}m` to seiload args in `clusters/harbor/nightly/templates/seiload-job.yaml`.
3. Optionally raises `JOB_DEADLINE_SECONDS` slightly to keep `activeDeadlineSeconds` as a backstop only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
